### PR TITLE
feat: allow dumping response buffer to some file

### DIFF
--- a/cffi_dist/main.go
+++ b/cffi_dist/main.go
@@ -235,7 +235,7 @@ func request(requestParams *C.char) *C.char {
 
 	targetCookies := tlsClient.GetCookies(resp.Request.URL)
 
-	response, err := tls_client_cffi_src.BuildResponse(sessionId, withSession, resp, targetCookies, requestInput.IsByteResponse)
+	response, err := tls_client_cffi_src.BuildResponse(sessionId, withSession, resp, targetCookies, requestInput)
 	if err != nil {
 		return handleErrorResponse(sessionId, withSession, err)
 	}

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -135,6 +135,47 @@ func BuildRequest(input RequestInput) (*http.Request, *TLSClientError) {
 	return tlsReq, nil
 }
 
+func readAllBodyWithStreamToFile(resp *http.Response, input RequestInput) ([]byte, *TLSClientError) {
+	var respBodyBytes []byte
+	var err error
+
+	f, err := os.OpenFile(*input.StreamOutputPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, NewTLSClientError(err)
+	}
+	defer f.Close()
+
+	blockSize := 1024 // 1 KB
+	if input.StreamOutputBlockSize != nil {
+		blockSize = *input.StreamOutputBlockSize
+	}
+	buf := make([]byte, blockSize)
+	// Read the response body
+	for {
+		n, err := resp.Body.Read(buf)
+		if err == io.EOF {
+			if input.StreamOutputEOFSymbol != nil {
+				f.Write([]byte(*input.StreamOutputEOFSymbol))
+			}
+			break
+		}
+
+		respBodyBytes = append(respBodyBytes, buf[:n]...)
+		if _, err = f.Write(buf[:n]); err != nil {
+			if input.WithDebug {
+				fmt.Printf("Append stream output error: %+v\n", err)
+			}
+			return nil, NewTLSClientError(err)
+		}
+
+		if input.WithDebug {
+			fmt.Printf("[stream decode result]==========\n%+v\n==========\n", string(buf[:n]))
+		}
+	}
+
+	return respBodyBytes, nil
+}
+
 // BuildResponse constructs a client response from a given HTTP response. The client response can then be sent to the interface consumer.
 func BuildResponse(sessionId string, withSession bool, resp *http.Response, cookies []*http.Cookie, input RequestInput) (Response, *TLSClientError) {
 	defer resp.Body.Close()
@@ -143,43 +184,7 @@ func BuildResponse(sessionId string, withSession bool, resp *http.Response, cook
 	var err error
 
 	if input.StreamOutputPath != nil {
-		f, err := os.OpenFile(*input.StreamOutputPath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
-		if err != nil {
-			panic(err)
-		}
-		defer f.Close()
-
-		blockSize := 1024 // 1 KB
-		if input.StreamOutputBlockSize != nil {
-			blockSize = *input.StreamOutputBlockSize
-		}
-		buf := make([]byte, blockSize)
-		// Read the response body
-		for {
-			n, err := resp.Body.Read(buf)
-			if err == io.EOF {
-				if input.StreamOutputEOFSymbol != nil {
-					f.Write([]byte(*input.StreamOutputEOFSymbol))
-				}
-				break
-			}
-
-			respBodyBytes = append(respBodyBytes, buf[:n]...)
-			if _, err = f.Write(buf[:n]); err != nil {
-				if input.WithDebug {
-					fmt.Printf("Append stream output error: %+v\n", err)
-				}
-				return Response{}, NewTLSClientError(err)
-			}
-
-			if input.WithDebug {
-				fmt.Printf("[stream decode result]==========\n%+v\n==========\n", string(buf[:n]))
-			}
-
-			if err != nil {
-				return Response{}, NewTLSClientError(err)
-			}
-		}
+		respBodyBytes, err = readAllBodyWithStreamToFile(resp, input)
 	} else {
 		respBodyBytes, err = io.ReadAll(resp.Body)
 	}

--- a/cffi_src/types.go
+++ b/cffi_src/types.go
@@ -71,6 +71,9 @@ type RequestInput struct {
 	RequestMethod               string              `json:"requestMethod"`
 	RequestBody                 *string             `json:"requestBody"`
 	RequestCookies              []CookieInput       `json:"requestCookies"`
+	StreamOutputPath            *string             `json:"streamOutputPath"`
+	StreamOutputBlockSize       *int                `json:"streamOutputBlockSize"`
+	StreamOutputEOFSymbol       *string             `json:"streamOutputEOFSymbol"`
 }
 
 // CustomTlsClient contains custom TLS specifications to construct a client from.


### PR DESCRIPTION
@bogdanfinn Hi this is a PR for enabling saving in-process bytes to given-path-file.

With this feature one can easily implement some callback functions from their app (with other languages they just need to watch the file).

May you help to review this ?