### PR TITLE
Add support for custom CA

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -1,6 +1,7 @@
 package tls_client
 
 import (
+	"crypto/x509"
 	"fmt"
 	"time"
 
@@ -21,6 +22,9 @@ type TransportOptions struct {
 	// IdleConnTimeout is the maximum amount of time an idle (keep-alive)
 	// connection will remain idle before closing itself. Zero means no limit.
 	IdleConnTimeout *time.Duration
+	// RootCAs is the set of root certificate authorities used to verify
+	// the remote server's certificate.
+	RootCAs *x509.CertPool
 }
 
 type BadPinHandlerFunc func(req *http.Request)

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -11,7 +11,7 @@ import (
 
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/http2"
-	"github.com/bogdanfinn/utls"
+	tls "github.com/bogdanfinn/utls"
 	"golang.org/x/net/proxy"
 )
 
@@ -118,7 +118,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 		host = rt.serverNameOverwrite
 	}
 
-	conn := tls.UClient(rawConn, &tls.Config{ServerName: host, InsecureSkipVerify: rt.insecureSkipVerify}, rt.clientHelloId, rt.withRandomTlsExtensionOrder, rt.forceHttp1)
+	conn := tls.UClient(rawConn, &tls.Config{ServerName: host, InsecureSkipVerify: rt.insecureSkipVerify, RootCAs: rt.transportOptions.RootCAs}, rt.clientHelloId, rt.withRandomTlsExtensionOrder, rt.forceHttp1)
 	if err = conn.Handshake(); err != nil {
 		_ = conn.Close()
 
@@ -140,7 +140,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 
 	switch conn.ConnectionState().NegotiatedProtocol {
 	case http2.NextProtoTLS:
-		utlsConfig := &tls.Config{InsecureSkipVerify: rt.insecureSkipVerify}
+		utlsConfig := &tls.Config{InsecureSkipVerify: rt.insecureSkipVerify, RootCAs: rt.transportOptions.RootCAs}
 
 		if rt.serverNameOverwrite != "" {
 			utlsConfig.ServerName = rt.serverNameOverwrite
@@ -224,7 +224,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 }
 
 func (rt *roundTripper) buildHttp1Transport() *http.Transport {
-	utlsConfig := &tls.Config{InsecureSkipVerify: rt.insecureSkipVerify}
+	utlsConfig := &tls.Config{InsecureSkipVerify: rt.insecureSkipVerify, RootCAs: rt.transportOptions.RootCAs}
 
 	if rt.serverNameOverwrite != "" {
 		utlsConfig.ServerName = rt.serverNameOverwrite


### PR DESCRIPTION
This pull request exposes RootCAs transport option to a user and allows the user to set their own root certificate bundle.

Motivation:
 - this should simplify work with services that use self-signed certificates. At the moment it is only possible if SSL certificate verification is skipped completely (insecureSkipVerify option)
 - some of the web servers do not provide full certificate chain, which often results in "unknown certificate authority" error. Browsers normally request the missing certificates themselves, however go's http client doesn't. One workaround would be to generate your own certificate bundle which includes both root CAs and intermidiate CAs

Details:
In this pr I made `RootCAs` a part of `TransportOptions` struct, which makes sense because it is a transport option. However, a similar `insecureSkipVerify` option is assigned as `HttpClientOption`. Should RootCAs be also assigned in a similar way as `insecureSkipVerify`? :thinking: 