### PR TITLE
An option to force tcp connections to ipv4 only

### DIFF
--- a/client.go
+++ b/client.go
@@ -135,7 +135,7 @@ func buildFromConfig(config *httpClientConfig) (*http.Client, ClientProfile, err
 
 	clientProfile := config.clientProfile
 
-	transport, err := newRoundTripper(clientProfile, config.transportOptions, config.serverNameOverwrite, config.insecureSkipVerify, config.withRandomTlsExtensionOrder, config.forceHttp1, config.certificatePins, config.badPinHandler, dialer)
+	transport, err := newRoundTripper(clientProfile, config.transportOptions, config.serverNameOverwrite, config.insecureSkipVerify, config.withRandomTlsExtensionOrder, config.forceHttp1, config.certificatePins, config.badPinHandler, config.disableIPV6, dialer)
 	if err != nil {
 		return nil, clientProfile, err
 	}
@@ -218,7 +218,7 @@ func (c *httpClient) applyProxy() error {
 		dialer = proxyDialer
 	}
 
-	transport, err := newRoundTripper(c.config.clientProfile, c.config.transportOptions, c.config.serverNameOverwrite, c.config.insecureSkipVerify, c.config.withRandomTlsExtensionOrder, c.config.forceHttp1, c.config.certificatePins, c.config.badPinHandler, dialer)
+	transport, err := newRoundTripper(c.config.clientProfile, c.config.transportOptions, c.config.serverNameOverwrite, c.config.insecureSkipVerify, c.config.withRandomTlsExtensionOrder, c.config.forceHttp1, c.config.certificatePins, c.config.badPinHandler, c.config.disableIPV6, dialer)
 	if err != nil {
 		return err
 	}

--- a/client_options.go
+++ b/client_options.go
@@ -47,6 +47,8 @@ type httpClientConfig struct {
 	forceHttp1                  bool
 	timeout                     time.Duration
 	localAddr                   *net.TCPAddr
+	// Establish a connection to origin server via ipv4 only
+	disableIPV6 bool
 }
 
 // WithProxyUrl configures a HTTP client to use the specified proxy URL.
@@ -206,5 +208,12 @@ func WithClientProfile(clientProfile ClientProfile) HttpClientOption {
 func WithServerNameOverwrite(serverName string) HttpClientOption {
 	return func(config *httpClientConfig) {
 		config.serverNameOverwrite = serverName
+	}
+}
+
+// WithDisableIPV6 configures a dialer to use tcp4 network argument
+func WithDisableIPV6() HttpClientOption {
+	return func(config *httpClientConfig) {
+		config.disableIPV6 = true
 	}
 }


### PR DESCRIPTION
## Description
This pr adds a new option to `HttpClientOption` called `disableIPV6`. If this option is set to true, the client will try to establish only tcp4 connections.

## Motivation
We have noticed that go http client by default prefers to use ipv6 addresses over ipv4 addresses. We also noticed that for some reason ipv6  addresses from Hetzner have very bad reputation (their support team said that some of the geolocation services detect their ipv6 addresses as ip addresses from Iran) which results in 403 response code. With this option, it is possible to prefer ipv4 connections over ipv6 ones.