### PR TITLE
Fixed Custom Redirect being used regardless if followRedirect is false

### DIFF
--- a/client.go
+++ b/client.go
@@ -180,7 +180,7 @@ func (c *httpClient) applyFollowRedirect() {
 		c.CheckRedirect = defaultRedirectFunc
 	}
 
-	if c.config.customRedirectFunc != nil {
+	if c.config.customRedirectFunc != nil && c.config.followRedirects {
 		c.CheckRedirect = c.config.customRedirectFunc
 	}
 }


### PR DESCRIPTION
In net/http, when defining a redirect function whether to follow or disable  redirects, you must always define a custom function in the transport. Using the custom redirect func in the clientConfig, it causes the .SetFollowRedirect() function to never work if provided with "false". By adding a check to ensure that follow redirects is enabled when updating the underlying client's transport, it allows you to enable and disable redirects per request, while also maintaining the custom redirect function when re-enabling follow redirects.