### PR TITLE
connection handshake fixes

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -289,7 +289,7 @@ func (c *connectDialer) DialContext(ctx context.Context, network, address string
 			if err != nil {
 				return nil, err
 			}
-			err = tlsConn.Handshake()
+			err = tlsConn.HandshakeContext(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -145,7 +145,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 	}
 
 	conn := tls.UClient(rawConn, tlsConfig, rt.clientHelloId, rt.withRandomTlsExtensionOrder, rt.forceHttp1)
-	if err = conn.Handshake(); err != nil {
+	if err = conn.HandshakeContext(ctx); err != nil {
 		_ = conn.Close()
 
 		return nil, err


### PR DESCRIPTION
When situations like network latency occur while using a proxy, the handshake process may take a very long time. Since the context is independent, the timeout process cannot be controlled with context. 