### PR TITLE
when RemoveSession close HttpClient

### DIFF
--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -28,6 +28,11 @@ var clients = make(map[string]tls_client.HttpClient)
 func RemoveSession(sessionId string) {
 	clientsLock.Lock()
 	defer clientsLock.Unlock()
+	client, ok := clients[sessionId]
+	if !ok {
+             return
+	}
+	client.CloseIdleConnections()
 
 	delete(clients, sessionId)
 }


### PR DESCRIPTION
When I use this library with Python, if I use different "sessionId" and use the destroySession() method, it is unable to close the connection of the tls_client.HttpClient created, which leads to a memory leak issue in Python.