### PR TITLE
Non-authorized proxy support added

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -135,10 +135,15 @@ func newConnectDialer(proxyUrlStr string, timeout time.Duration, localAddr *net.
 
 	if proxyUrl.User != nil {
 		if proxyUrl.User.Username() != "" {
+			//example format (with credentials): http://root:xxx@127.0.0.1:12312
 			password, _ := proxyUrl.User.Password()
 			dialer.DefaultHeader.Set("Proxy-Authorization", "Basic "+
 				base64.StdEncoding.EncodeToString([]byte(proxyUrl.User.Username()+":"+password)))
+
 		}
+	} else {
+		//example format (without credentials): http://127.0.0.1:12312
+		dialer.DefaultHeader.Set("Proxy-Authorization", "")
 	}
 	return dialer, nil
 }


### PR DESCRIPTION
The library itself has proxy support that only requires Proxy-Authorization. I made a small condition update to be able to use proxy services that do not require public or authorization.

![nonauthorized](https://github.com/bogdanfinn/tls-client/assets/31545391/42fd8f90-d450-4499-a14c-06017eeeacfb)
