### PR TITLE
Add KeyLogWriter parameter to TransportOptions.

### DIFF
--- a/client_options.go
+++ b/client_options.go
@@ -3,9 +3,11 @@ package tls_client
 import (
 	"crypto/x509"
 	"fmt"
-	"github.com/bogdanfinn/tls-client/profiles"
+	"io"
 	"net"
 	"time"
+
+	"github.com/bogdanfinn/tls-client/profiles"
 
 	http "github.com/bogdanfinn/fhttp"
 )
@@ -27,6 +29,10 @@ type TransportOptions struct {
 	// RootCAs is the set of root certificate authorities used to verify
 	// the remote server's certificate.
 	RootCAs *x509.CertPool
+	// KeyLogWriter is an io.Writer that the TLS client will use to write the
+	// TLS master secrets to. This can be used to decrypt TLS connections in
+	// Wireshark and other applications.
+	KeyLogWriter io.Writer
 }
 
 type BadPinHandlerFunc func(req *http.Request)

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -141,9 +141,10 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 		host = rt.serverNameOverwrite
 	}
 
-	tlsConfig := &tls.Config{ClientSessionCache: rt.clientSessionCache, ServerName: host, InsecureSkipVerify: rt.insecureSkipVerify, OmitEmptyPsk: true, KeyLogWriter: rt.transportOptions.KeyLogWriter}
+	tlsConfig := &tls.Config{ClientSessionCache: rt.clientSessionCache, ServerName: host, InsecureSkipVerify: rt.insecureSkipVerify, OmitEmptyPsk: true}
 	if rt.transportOptions != nil {
 		tlsConfig.RootCAs = rt.transportOptions.RootCAs
+		tlsConfig.KeyLogWriter = rt.transportOptions.KeyLogWriter
 	}
 
 	conn := tls.UClient(rawConn, tlsConfig, rt.clientHelloId, rt.withRandomTlsExtensionOrder, rt.forceHttp1)

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -141,7 +141,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 		host = rt.serverNameOverwrite
 	}
 
-	tlsConfig := &tls.Config{ClientSessionCache: rt.clientSessionCache, ServerName: host, InsecureSkipVerify: rt.insecureSkipVerify, OmitEmptyPsk: true}
+	tlsConfig := &tls.Config{ClientSessionCache: rt.clientSessionCache, ServerName: host, InsecureSkipVerify: rt.insecureSkipVerify, OmitEmptyPsk: true, KeyLogWriter: rt.transportOptions.KeyLogWriter}
 	if rt.transportOptions != nil {
 		tlsConfig.RootCAs = rt.transportOptions.RootCAs
 	}


### PR DESCRIPTION
`KeyLogWriter` allows users of the library to provide an `io.Writer` to the underlying TLS client in order to log TLS secrets to a file, in order to make debugging easier with Wireshark and other applications.