### PR TITLE
Add bandwidth tracker feature

### DIFF
--- a/bandwidth_tracker.go
+++ b/bandwidth_tracker.go
@@ -1,0 +1,55 @@
+package tls_client
+
+import (
+	"net"
+	"sync/atomic"
+)
+
+type btConn struct {
+	net.Conn
+	tracker *bandwidthTracker
+}
+
+func (bt *btConn) Read(p []byte) (n int, err error) {
+	n, err = bt.Conn.Read(p)
+	bt.tracker.AddReadBytes(int64(n))
+	return n, err
+}
+
+func (bt *btConn) Write(p []byte) (n int, err error) {
+	n, err = bt.Conn.Write(p)
+	bt.tracker.AddWriteBytes(int64(n))
+	return n, err
+}
+
+func newBandwidthTrackedConn(conn net.Conn, tracker *bandwidthTracker) *btConn {
+	return &btConn{
+		Conn:    conn,
+		tracker: tracker,
+	}
+}
+
+type bandwidthTracker struct {
+	writeBytes atomic.Int64
+	readBytes  atomic.Int64
+}
+
+func (bt *bandwidthTracker) AddWriteBytes(n int64) {
+	bt.writeBytes.Add(n)
+}
+
+func (bt *bandwidthTracker) AddReadBytes(n int64) {
+	bt.readBytes.Add(n)
+}
+
+func (bt *bandwidthTracker) GetWriteBytes() int64 {
+	return bt.writeBytes.Load()
+}
+
+func (bt *bandwidthTracker) GetReadBytes() int64 {
+	return bt.readBytes.Load()
+}
+
+func newBandwidthTracker() *bandwidthTracker {
+	return &bandwidthTracker{}
+}

--- a/client.go
+++ b/client.go
@@ -35,6 +35,9 @@ type HttpClient interface {
 	Get(url string) (resp *http.Response, err error)
 	Head(url string) (resp *http.Response, err error)
 	Post(url, contentType string, body io.Reader) (resp *http.Response, err error)
+
+	GetReadBytes() int64
+	GetWriteBytes() int64
 }
 
 // Interface guards are a cheap way to make sure all methods are implemented, this is a static check and does not affect runtime performance.
@@ -45,6 +48,16 @@ type httpClient struct {
 	headerLck sync.Mutex
 	logger    Logger
 	config    *httpClientConfig
+
+	bandwidthTracker *bandwidthTracker
+}
+
+func (c *httpClient) GetReadBytes() int64 {
+	return c.bandwidthTracker.GetReadBytes()
+}
+
+func (c *httpClient) GetWriteBytes() int64 {
+	return c.bandwidthTracker.GetWriteBytes()
 }
 
 var DefaultTimeoutSeconds = 30
@@ -81,7 +94,7 @@ func NewHttpClient(logger Logger, options ...HttpClientOption) (HttpClient, erro
 		return nil, err
 	}
 
-	client, clientProfile, err := buildFromConfig(logger, config)
+	client, bandwidthTracker, clientProfile, err := buildFromConfig(logger, config)
 	if err != nil {
 		return nil, err
 	}
@@ -101,10 +114,11 @@ func NewHttpClient(logger Logger, options ...HttpClientOption) (HttpClient, erro
 	}
 
 	return &httpClient{
-		Client:    *client,
-		logger:    logger,
-		config:    config,
-		headerLck: sync.Mutex{},
+		Client:           *client,
+		logger:           logger,
+		config:           config,
+		headerLck:        sync.Mutex{},
+		bandwidthTracker: bandwidthTracker,
 	}, nil
 }
 
@@ -112,14 +126,14 @@ func validateConfig(_ *httpClientConfig) error {
 	return nil
 }
 
-func buildFromConfig(logger Logger, config *httpClientConfig) (*http.Client, profiles.ClientProfile, error) {
+func buildFromConfig(logger Logger, config *httpClientConfig) (*http.Client, *bandwidthTracker, profiles.ClientProfile, error) {
 	var dialer proxy.ContextDialer
 	dialer = newDirectDialer(config.timeout, config.localAddr, config.dialer)
 
 	if config.proxyUrl != "" {
 		proxyDialer, err := newConnectDialer(config.proxyUrl, config.timeout, config.localAddr, config.dialer, logger)
 		if err != nil {
-			return nil, profiles.ClientProfile{}, err
+			return nil, nil, profiles.ClientProfile{}, err
 		}
 
 		dialer = proxyDialer
@@ -136,11 +150,13 @@ func buildFromConfig(logger Logger, config *httpClientConfig) (*http.Client, pro
 		}
 	}
 
+	bandwidthTracker := newBandwidthTracker()
+
 	clientProfile := config.clientProfile
 
-	transport, err := newRoundTripper(clientProfile, config.transportOptions, config.serverNameOverwrite, config.insecureSkipVerify, config.withRandomTlsExtensionOrder, config.forceHttp1, config.certificatePins, config.badPinHandler, config.disableIPV6, dialer)
+	transport, err := newRoundTripper(clientProfile, config.transportOptions, config.serverNameOverwrite, config.insecureSkipVerify, config.withRandomTlsExtensionOrder, config.forceHttp1, config.certificatePins, config.badPinHandler, config.disableIPV6, bandwidthTracker, dialer)
 	if err != nil {
-		return nil, clientProfile, err
+		return nil, nil, clientProfile, err
 	}
 
 	client := &http.Client{
@@ -153,7 +169,7 @@ func buildFromConfig(logger Logger, config *httpClientConfig) (*http.Client, pro
 		client.Jar = config.cookieJar
 	}
 
-	return client, clientProfile, nil
+	return client, bandwidthTracker, clientProfile, nil
 }
 
 // CloseIdleConnections closes all idle connections of the underlying http client.
@@ -230,7 +246,7 @@ func (c *httpClient) applyProxy() error {
 		dialer = proxyDialer
 	}
 
-	transport, err := newRoundTripper(c.config.clientProfile, c.config.transportOptions, c.config.serverNameOverwrite, c.config.insecureSkipVerify, c.config.withRandomTlsExtensionOrder, c.config.forceHttp1, c.config.certificatePins, c.config.badPinHandler, c.config.disableIPV6, dialer)
+	transport, err := newRoundTripper(c.config.clientProfile, c.config.transportOptions, c.config.serverNameOverwrite, c.config.insecureSkipVerify, c.config.withRandomTlsExtensionOrder, c.config.forceHttp1, c.config.certificatePins, c.config.badPinHandler, c.config.disableIPV6, c.bandwidthTracker, dialer)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -36,8 +36,7 @@ type HttpClient interface {
 	Head(url string) (resp *http.Response, err error)
 	Post(url, contentType string, body io.Reader) (resp *http.Response, err error)
 
-	GetReadBytes() int64
-	GetWriteBytes() int64
+	GetBandwidthTracker() BandwidthTracker
 }
 
 // Interface guards are a cheap way to make sure all methods are implemented, this is a static check and does not affect runtime performance.
@@ -50,14 +49,6 @@ type httpClient struct {
 	config    *httpClientConfig
 
 	bandwidthTracker *bandwidthTracker
-}
-
-func (c *httpClient) GetReadBytes() int64 {
-	return c.bandwidthTracker.GetReadBytes()
-}
-
-func (c *httpClient) GetWriteBytes() int64 {
-	return c.bandwidthTracker.GetWriteBytes()
 }
 
 var DefaultTimeoutSeconds = 30
@@ -287,6 +278,11 @@ func (c *httpClient) SetCookieJar(jar http.CookieJar) {
 // GetCookieJar returns the jar the client is currently using
 func (c *httpClient) GetCookieJar() http.CookieJar {
 	return c.Jar
+}
+
+// GetBandwidthTracker returns the bandwidth tracker
+func (c *httpClient) GetBandwidthTracker() BandwidthTracker {
+	return c.bandwidthTracker
 }
 
 // Do issues a given HTTP request and returns the corresponding response.


### PR DESCRIPTION
Instead of trying to calculate bandwidth based on requests and responses, this approach wraps the underlying raw connection and tracks the total amount of bytes being read and written. This approach will therefore also take into account bytes used for tls handshakes.