### PR TITLE
Support defining useragent in connect request

### DIFF
--- a/client.go
+++ b/client.go
@@ -122,7 +122,7 @@ func buildFromConfig(logger Logger, config *httpClientConfig) (*http.Client, ban
 	dialer = newDirectDialer(config.timeout, config.localAddr, config.dialer)
 
 	if config.proxyUrl != "" {
-		proxyDialer, err := newConnectDialer(config.proxyUrl, config.timeout, config.localAddr, config.dialer, logger)
+		proxyDialer, err := newConnectDialer(config.proxyUrl, config.timeout, config.localAddr, config.dialer, logger, config.userAgent)
 		if err != nil {
 			return nil, nil, profiles.ClientProfile{}, err
 		}
@@ -233,7 +233,7 @@ func (c *httpClient) applyProxy() error {
 
 	if c.config.proxyUrl != "" {
 		c.logger.Debug("proxy url %s supplied - using proxy connect dialer", c.config.proxyUrl)
-		proxyDialer, err := newConnectDialer(c.config.proxyUrl, c.config.timeout, c.config.localAddr, c.config.dialer, c.logger)
+		proxyDialer, err := newConnectDialer(c.config.proxyUrl, c.config.timeout, c.config.localAddr, c.config.dialer, c.logger, c.config.userAgent)
 		if err != nil {
 			c.logger.Error("failed to create proxy connect dialer: %s", err.Error())
 			return err

--- a/client_options.go
+++ b/client_options.go
@@ -50,6 +50,7 @@ type httpClientConfig struct {
 	transportOptions            *TransportOptions
 	cookieJar                   http.CookieJar
 	clientProfile               profiles.ClientProfile
+	userAgent                   string
 	withRandomTlsExtensionOrder bool
 	forceHttp1                  bool
 	timeout                     time.Duration
@@ -72,6 +73,13 @@ type httpClientConfig struct {
 func WithProxyUrl(proxyUrl string) HttpClientOption {
 	return func(config *httpClientConfig) {
 		config.proxyUrl = proxyUrl
+	}
+}
+
+// /Use useragent in the CONNECT request
+func WithConnectUserAgent(userAgent string) HttpClientOption {
+	return func(config *httpClientConfig) {
+		config.userAgent = userAgent
 	}
 }
 

--- a/connect.go
+++ b/connect.go
@@ -94,7 +94,7 @@ type connectDialer struct {
 // newConnectDialer creates a dialer to issue CONNECT requests and tunnel traffic via HTTP/S proxy.
 // proxyUrlStr must provide Scheme and Host, may provide credentials and port.
 // Example: https://username:password@golang.org:443
-func newConnectDialer(proxyUrlStr string, timeout time.Duration, localAddr *net.TCPAddr, configDialer net.Dialer, logger Logger) (proxy.ContextDialer, error) {
+func newConnectDialer(proxyUrlStr string, timeout time.Duration, localAddr *net.TCPAddr, configDialer net.Dialer, logger Logger, userAgent string) (proxy.ContextDialer, error) {
 	proxyUrl, err := url.Parse(proxyUrlStr)
 	if err != nil {
 		return nil, err
@@ -147,6 +147,9 @@ func newConnectDialer(proxyUrlStr string, timeout time.Duration, localAddr *net.
 	} else {
 		//example format (without credentials): http://127.0.0.1:12312
 		dialer.DefaultHeader.Set("Proxy-Authorization", "")
+	}
+	if userAgent != "" {
+		dialer.DefaultHeader.Set("User-Agent", userAgent)
 	}
 	return dialer, nil
 }

--- a/example/main.go
+++ b/example/main.go
@@ -172,6 +172,7 @@ func requestToppsAsChrome107Client() {
 		// tls_client.WithNotFollowRedirects(),
 		// tls_client.WithInsecureSkipVerify(),
 		tls_client.WithCookieJar(jar), // create cookieJar instance and pass it as argument
+		//tls_client.WithConnectUserAgent("TestUA"),
 	}
 
 	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)


### PR DESCRIPTION
The CONNECT request contains a useragent which we can set in the connect.go

(not a golang coder typically so please feel free to raise any issues this may have)