### PR TITLE
Fixed `connectHeaders` concurrent map read & write

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -132,7 +132,7 @@ func newConnectDialer(proxyUrlStr string, timeout time.Duration, localAddr *net.
 		ProxyUrl:          *proxyUrl,
 		Dialer:            _dialer,
 		Timeout:           timeout,
-		DefaultHeader:     connectHeaders,
+		DefaultHeader:     connectHeaders.Clone(),
 		EnableH2ConnReuse: true,
 	}
 


### PR DESCRIPTION
In the latest update the possibility to define `CONNECT` headers was implemented, I encountered a bug with this new feature when setting a proxy to the client instance very quickly, that causes a race condition.

When setting a new proxy, the `connectDialer` will write the proxy authentication credentials to the `DefaultHeader` map. This caused no issue in previous versions because a new header map was spawned every time (`make(http.Header)`) but in this version the same map is used, the `connectHeaders` one.

Since writing and reading a map concurrently in go isn't supported, when lots of proxy change operations are happening it will eventually panic because two threads will try to write to the same map at the same time.

To fix this, I've implemented the built-in `Clone()` method to clone the header map, so every instance will have its own header map and nothing else will be trying to read or write to it.