### PR TITLE
Updated default client profile; Added Reset() method in bandwidth tracker

### DIFF
--- a/bandwidth/nope_tracker.go
+++ b/bandwidth/nope_tracker.go
@@ -8,6 +8,8 @@ import (
 type NopeTracker struct {
 }
 
+func (bt *NopeTracker) Reset() {}
+
 func (bt *NopeTracker) GetWriteBytes() int64 {
 	return 0
 }

--- a/bandwidth/tracker.go
+++ b/bandwidth/tracker.go
@@ -7,6 +7,7 @@ import (
 )
 
 type BandwidthTracker interface {
+	Reset()
 	GetTotalBandwidth() int64
 	GetWriteBytes() int64
 	GetReadBytes() int64
@@ -16,6 +17,11 @@ type BandwidthTracker interface {
 type Tracker struct {
 	writeBytes atomic.Int64
 	readBytes  atomic.Int64
+}
+
+func (bt *Tracker) Reset() {
+	bt.writeBytes.Store(0)
+	bt.readBytes.Store(0)
 }
 
 func (bt *Tracker) GetWriteBytes() int64 {

--- a/profiles/profiles.go
+++ b/profiles/profiles.go
@@ -5,7 +5,7 @@ import (
 	tls "github.com/bogdanfinn/utls"
 )
 
-var DefaultClientProfile = Chrome_124
+var DefaultClientProfile = Chrome_131
 
 var MappedTLSClients = map[string]ClientProfile{
 	"chrome_103":             Chrome_103,


### PR DESCRIPTION
Latest (chrome) client profile is 131 as of right now, so that should be the default.

Added Reset() method in bandwidth tracker, which felt (and is) necessary to me.