### PR TITLE
fix: unassigned error in example

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -152,7 +152,7 @@ func sslPinning() {
 		return
 	}
 
-	resp.Body.Close()
+	err = resp.Body.Close()
 
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
Made a minor adjustment in the `sslPinning()` example to properly handle the potential `error` from [`io.Closer.Close()`](https://pkg.go.dev/io#Closer.Close), resolving the `nil != nil` impossible condition warning.