### PR TITLE
updated pinner to update pins in case they change per pinner instance

### DIFF
--- a/pinner.go
+++ b/pinner.go
@@ -3,6 +3,7 @@ package tls_client
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
 	http "github.com/bogdanfinn/fhttp"
@@ -53,8 +54,8 @@ func (cp *certificatePinner) init() error {
 
 		pinnedHost := certificatePinStorage.Lookup(host)
 
-		if pinnedHost != nil {
-			// another pinner instance already initialized the host. we do not need to pin again
+		if pinnedHost != nil && reflect.DeepEqual(pinnedHost.Sha256Pins, pinsByHost) {
+			// another pinner instance with the same Pins already initialized the host. we do not need to pin again
 			continue
 		}
 


### PR DESCRIPTION
Before the pinner instance would not be updated if the Sha256Pins were updated for the same host inbetween two requests.

Now, the pinner will update the pins if they change.