### PR TITLE
Update the spec factory 

### DIFF
--- a/ja3.go
+++ b/ja3.go
@@ -14,7 +14,7 @@ type CandidateCipherSuites struct {
 	AeadId string
 }
 
-func GetSpecFactoryFromJa3String(ja3String string, supportedSignatureAlgorithms, supportedDelegatedCredentialsAlgorithms, supportedVersions, keyShareCurves, supportedProtocolsALPN, supportedProtocolsALPS []string, echCandidateCipherSuites []CandidateCipherSuites, candidatePayloads []uint16, certCompressionAlgo string) (func() (tls.ClientHelloSpec, error), error) {
+func GetSpecFactoryFromJa3String(ja3String string, supportedSignatureAlgorithms, supportedDelegatedCredentialsAlgorithms, supportedVersions, keyShareCurves, supportedProtocolsALPN, supportedProtocolsALPS []string, echCandidateCipherSuites []CandidateCipherSuites, candidatePayloads []uint16, certCompressionAlgorithms []string) (func() (tls.ClientHelloSpec, error), error) {
 	return func() (tls.ClientHelloSpec, error) {
 		var mappedSignatureAlgorithms []tls.SignatureScheme
 
@@ -106,17 +106,20 @@ func GetSpecFactoryFromJa3String(ja3String string, supportedSignatureAlgorithms,
 			mappedKeyShares = append(mappedKeyShares, mappedKeyShare)
 		}
 
-		compressionAlgo, ok := certCompression[certCompressionAlgo]
+		var mappedCertCompressionAlgorithms []tls.CertCompressionAlgo
 
-		if !ok {
-			return stringToSpec(ja3String, mappedSignatureAlgorithms, mappedDelegatedCredentialsAlgorithms, mappedTlsVersions, mappedKeyShares, mappedHpkeSymmetricCipherSuites, candidatePayloads, supportedProtocolsALPN, supportedProtocolsALPS, nil)
+		for _, certCompressionAlgorithm := range certCompressionAlgorithms {
+			compressionAlgo, ok := certCompression[certCompressionAlgorithm]
+			if ok {
+				mappedCertCompressionAlgorithms = append(mappedCertCompressionAlgorithms, compressionAlgo)
+			}
 		}
 
-		return stringToSpec(ja3String, mappedSignatureAlgorithms, mappedDelegatedCredentialsAlgorithms, mappedTlsVersions, mappedKeyShares, mappedHpkeSymmetricCipherSuites, candidatePayloads, supportedProtocolsALPN, supportedProtocolsALPS, &compressionAlgo)
+		return stringToSpec(ja3String, mappedSignatureAlgorithms, mappedDelegatedCredentialsAlgorithms, mappedTlsVersions, mappedKeyShares, mappedHpkeSymmetricCipherSuites, candidatePayloads, supportedProtocolsALPN, supportedProtocolsALPS, mappedCertCompressionAlgorithms)
 	}, nil
 }
 
-func stringToSpec(ja3 string, signatureAlgorithms []tls.SignatureScheme, delegatedCredentialsAlgorithms []tls.SignatureScheme, tlsVersions []uint16, keyShares []tls.KeyShare, hpkeSymmetricCipherSuites []tls.HPKESymmetricCipherSuite, candidatePayloads []uint16, supportedProtocolsALPN, supportedProtocolsALPS []string, certCompression *tls.CertCompressionAlgo) (tls.ClientHelloSpec, error) {
+func stringToSpec(ja3 string, signatureAlgorithms []tls.SignatureScheme, delegatedCredentialsAlgorithms []tls.SignatureScheme, tlsVersions []uint16, keyShares []tls.KeyShare, hpkeSymmetricCipherSuites []tls.HPKESymmetricCipherSuite, candidatePayloads []uint16, supportedProtocolsALPN, supportedProtocolsALPS []string, certCompressionAlgorithms []tls.CertCompressionAlgo) (tls.ClientHelloSpec, error) {
 	extMap := getExtensionBaseMap()
 	ja3StringParts := strings.Split(ja3, ",")
 
@@ -154,12 +157,12 @@ func stringToSpec(ja3 string, signatureAlgorithms []tls.SignatureScheme, delegat
 		targetPointFormats = append(targetPointFormats, byte(pid))
 	}
 
-	if certCompression == nil && strings.Contains(ja3StringParts[2], fmt.Sprintf("%d", tls.ExtensionCompressCertificate)) {
+	if len(certCompressionAlgorithms) == 0 && strings.Contains(ja3StringParts[2], fmt.Sprintf("%d", tls.ExtensionCompressCertificate)) {
 		fmt.Println("attention our ja3 defines ExtensionCompressCertificate but you did not specify certCompression")
 	}
 
-	if certCompression != nil {
-		extMap[tls.ExtensionCompressCertificate] = &tls.UtlsCompressCertExtension{Algorithms: []tls.CertCompressionAlgo{*certCompression}}
+	if len(certCompressionAlgorithms) != 0 {
+		extMap[tls.ExtensionCompressCertificate] = &tls.UtlsCompressCertExtension{Algorithms: certCompressionAlgorithms}
 	}
 
 	extMap[tls.ExtensionKeyShare] = &tls.KeyShareExtension{KeyShares: keyShares}

--- a/mapper.go
+++ b/mapper.go
@@ -79,6 +79,7 @@ var curves = map[string]tls.CurveID{
 	"P256Kyber768":    tls.P256Kyber768Draft00,
 	"X25519Kyber512D": tls.X25519Kyber512Draft00,
 	"X25519Kyber768":  tls.X25519Kyber768Draft00,
+	"X25519MLKEM768":  tls.X25519MLKEM768,
 }
 
 var certCompression = map[string]tls.CertCompressionAlgo{

--- a/tests/ja3_test.go
+++ b/tests/ja3_test.go
@@ -46,8 +46,9 @@ func ja3_chrome_120(t *testing.T) {
 		},
 	}
 	cp := []uint16{128, 160, 192, 224}
+	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, ccs, cp, "zlib")
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, ccs, cp, ca)
 
 	if err != nil {
 		t.Fatal(err)
@@ -71,8 +72,9 @@ func ja3_chrome_112_with_psk(t *testing.T) {
 	sc := []string{"GREASE", "X25519"}
 	alpnProtocols := []string{"h2", "http/1.1"}
 	alpsProtocols := []string{"h2"}
+	ca := []string{"brotli"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, "brotli")
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
 
 	if err != nil {
 		t.Fatal(err)
@@ -96,8 +98,9 @@ func ja3_chrome_105(t *testing.T) {
 	sc := []string{"GREASE", "X25519"}
 	alpnProtocols := []string{"h2", "http/1.1"}
 	alpsProtocols := []string{"h2"}
+	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, "zlib")
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
 
 	if err != nil {
 		t.Fatal(err)
@@ -121,8 +124,9 @@ func ja3_chrome_107(t *testing.T) {
 	sc := []string{"GREASE", "X25519"}
 	alpnProtocols := []string{"h2", "http/1.1"}
 	alpsProtocols := []string{"h2"}
+	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, "zlib")
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
 
 	if err != nil {
 		t.Fatal(err)
@@ -146,8 +150,9 @@ func ja3_firefox_105(t *testing.T) {
 	sc := []string{"GREASE", "X25519"}
 	alpnProtocols := []string{"h2", "http/1.1"}
 	alpsProtocols := []string{"h2"}
+	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, "zlib")
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
 
 	if err != nil {
 		t.Fatal(err)
@@ -171,8 +176,9 @@ func ja3_opera_91(t *testing.T) {
 	sc := []string{"GREASE", "X25519"}
 	alpnProtocols := []string{"h2", "http/1.1"}
 	alpsProtocols := []string{"h2"}
+	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, "zlib")
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
 
 	if err != nil {
 		t.Fatal(err)

--- a/tests/ja3_test.go
+++ b/tests/ja3_test.go
@@ -48,7 +48,7 @@ func ja3_chrome_120(t *testing.T) {
 	cp := []uint16{128, 160, 192, 224}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, ccs, cp, ca)
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, ccs, cp, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -74,7 +74,7 @@ func ja3_chrome_112_with_psk(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"brotli"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -100,7 +100,7 @@ func ja3_chrome_105(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -126,7 +126,7 @@ func ja3_chrome_107(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -152,7 +152,7 @@ func ja3_firefox_105(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)
@@ -178,7 +178,7 @@ func ja3_opera_91(t *testing.T) {
 	alpsProtocols := []string{"h2"}
 	ca := []string{"zlib"}
 
-	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca)
+	specFunc, err := tls_client.GetSpecFactoryFromJa3String(input, ssa, dca, sv, sc, alpnProtocols, alpsProtocols, nil, nil, ca, 0)
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
While browsing [the docs](https://bogdanfinn.gitbook.io/open-source-oasis/tls-client/custom-client-profile) I stumbled upon the custom profiles via the spec factory. It seems that it was not updated in quite some time. 

- Added support for a list of cert compression algos
- Added the X25519MLKEM768 key share
- Added recordSizeLimit extension to the factory as it exposed no control over that and it was needed for mimicking the fingerprint
- Updated the tests that use the factory
