### PR TITLE
feat: HTTP/3 fingerprinting for Chrome 144 and Firefox 147

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,8 +21,24 @@ With this library you are able to create a http client implementing an interface
 client interface.
 This TLS Client allows you to specify the Client (Browser and Version) you want to use, when requesting a server.
 
-The Interface of the HTTP Client looks like the following and extends the base net/http Client Interface by some useful functions.
-Most likely you will use the `Do()` function like you did before with net/http Client.
+### Features
+
+- ✅ **HTTP/1.1, HTTP/2, HTTP/3** - Full protocol support with automatic negotiation
+- ✅ **Protocol Racing** - Chrome-like "Happy Eyeballs" for HTTP/2 vs HTTP/3
+- ✅ **TLS Fingerprinting** - Mimic Chrome, Firefox, Safari, and other browsers
+- ✅ **HTTP/3 Fingerprinting** - Accurate QUIC/HTTP/3 fingerprints matching real browsers
+- ✅ **WebSocket Support** - Maintain TLS fingerprinting over WebSocket connections
+- ✅ **Custom Header Ordering** - Control the order of HTTP headers
+- ✅ **Proxy Support** - HTTP and SOCKS5 proxies
+- ✅ **Cookie Jar Management** - Built-in cookie handling
+- ✅ **Certificate Pinning** - Enhanced security with custom certificate validation
+- ✅ **Bandwidth Tracking** - Monitor upload/download bandwidth
+- ✅ **Language Bindings** - Use from JavaScript (Node.js), Python, and C# via FFI
+
+### Interface
+
+The HTTP Client interface extends the base net/http Client with additional functionality:
+
 ```go
 type HttpClient interface {
     GetCookies(u *url.URL) []*http.Cookie
@@ -38,9 +54,15 @@ type HttpClient interface {
     Get(url string) (resp *http.Response, err error)
     Head(url string) (resp *http.Response, err error)
     Post(url, contentType string, body io.Reader) (resp *http.Response, err error)
+
+    GetBandwidthTracker() bandwidth.BandwidthTracker
+    GetDialer() proxy.ContextDialer
 }
 ```
 
+### Detailed Documentation
+
+https://bogdanfinn.gitbook.io/open-source-oasis/
 
 ### Quick Usage Example
 
@@ -58,10 +80,10 @@ import (
 )
 
 func main() {
-    jar := tls_client.NewCookieJar()
+	jar := tls_client.NewCookieJar()
 	options := []tls_client.HttpClientOption{
 		tls_client.WithTimeoutSeconds(30),
-		tls_client.WithClientProfile(profiles.Chrome_120),
+		tls_client.WithClientProfile(profiles.Chrome_133),
 		tls_client.WithNotFollowRedirects(),
 		tls_client.WithCookieJar(jar), // create cookieJar instance and pass it as argument
 	}
@@ -108,10 +130,6 @@ func main() {
 	log.Println(string(readBytes))
 }
 ```
-
-### Detailed Documentation
-
-https://bogdanfinn.gitbook.io/open-source-oasis/
 
 ### Questions?
 

--- a/cffi_src/types.go
+++ b/cffi_src/types.go
@@ -92,10 +92,13 @@ type RequestInput struct {
 // CustomTlsClient contains custom TLS specifications to construct a client from.
 type CustomTlsClient struct {
 	H2Settings                              map[string]uint32     `json:"h2Settings"`
+	H2SettingsOrder                         []string              `json:"h2SettingsOrder"`
+	H3Settings                              map[string]uint64     `json:"h3Settings"`
+	H3SettingsOrder                         []string              `json:"h3SettingsOrder"`
+	H3PseudoHeaderOrder                     []string              `json:"h3PseudoHeaderOrder"`
 	HeaderPriority                          *PriorityParam        `json:"headerPriority"`
 	CertCompressionAlgos                    []string              `json:"certCompressionAlgos"`
 	Ja3String                               string                `json:"ja3String"`
-	H2SettingsOrder                         []string              `json:"h2SettingsOrder"`
 	KeyShareCurves                          []string              `json:"keyShareCurves"`
 	ALPNProtocols                           []string              `json:"alpnProtocols"`
 	ALPSProtocols                           []string              `json:"alpsProtocols"`
@@ -109,6 +112,8 @@ type CustomTlsClient struct {
 	ConnectionFlow                          uint32                `json:"connectionFlow"`
 	RecordSizeLimit                         uint16                `json:"recordSizeLimit"`
 	StreamId                                uint32                `json:"streamId"`
+	H3PriorityParam                         uint32                `json:"h3PriorityParam"`
+	H3SendGreaseFrames                      bool                  `json:"h3SendGreaseFrames"`
 	AllowHttp                               bool                  `json:"allowHttp"`
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -691,7 +691,7 @@ func requestWithCustomClient() {
 		Version:     "1",
 		Seed:        nil,
 		SpecFactory: specFactory,
-	}, settings, settingsOrder, pseudoHeaderOrder, connectionFlow, nil, nil, 0, false)
+	}, settings, settingsOrder, pseudoHeaderOrder, connectionFlow, nil, nil, 0, false, nil, nil, 0, nil, false)
 
 	options := []tls_client.HttpClientOption{
 		tls_client.WithTimeoutSeconds(60),
@@ -814,7 +814,7 @@ func requestWithJa3CustomClientWithTwoGreaseExtensions() {
 		Version:     "1",
 		Seed:        nil,
 		SpecFactory: specFactory,
-	}, settings, settingsOrder, pseudoHeaderOrder, connectionFlow, nil, nil, 0, false)
+	}, settings, settingsOrder, pseudoHeaderOrder, connectionFlow, nil, nil, 0, false, nil, nil, 0, nil, false)
 
 	options := []tls_client.HttpClientOption{
 		tls_client.WithTimeoutSeconds(60),
@@ -957,7 +957,7 @@ func testPskExtension() {
 		Version:     "1",
 		Seed:        nil,
 		SpecFactory: specFactory,
-	}, settings, settingsOrder, pseudoHeaderOrder, connectionFlow, nil, nil, 0, false)
+	}, settings, settingsOrder, pseudoHeaderOrder, connectionFlow, nil, nil, 0, false, nil, nil, 0, nil, false)
 
 	options := []tls_client.HttpClientOption{
 		tls_client.WithTimeoutSeconds(60),

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.1
 require (
 	github.com/bdandy/go-socks4 v1.2.3
 	github.com/bogdanfinn/fhttp v0.6.7
-	github.com/bogdanfinn/quic-go-utls v1.0.7-utls
+	github.com/bogdanfinn/quic-go-utls v1.0.8-utls
 	github.com/bogdanfinn/utls v1.7.7-barnius
 	github.com/bogdanfinn/websocket v1.5.4-barnius
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/bdandy/go-socks4 v1.2.3 h1:Q6Y2heY1GRjCtHbmlKfnwrKVU/k81LS8mRGLRlmDli
 github.com/bdandy/go-socks4 v1.2.3/go.mod h1:98kiVFgpdogR8aIGLWLvjDVZ8XcKPsSI/ypGrO+bqHI=
 github.com/bogdanfinn/fhttp v0.6.7 h1:yTDywa9INbRqePBE5gHhpxlMjvAQ0bdX77pvOTPJoPI=
 github.com/bogdanfinn/fhttp v0.6.7/go.mod h1:A+EKDzMx2hb4IUbMx4TlkoHnaJEiLl8r/1Ss1Y+5e5M=
-github.com/bogdanfinn/quic-go-utls v1.0.7-utls h1:opxU/wt2C6FcD3rkGSOwfpQgfGSFx9eAKYQrFwYBzuo=
-github.com/bogdanfinn/quic-go-utls v1.0.7-utls/go.mod h1:bk8QMY2KypO8A6LzHJ7C4+bdB0ksLOd6NZt600wXYe8=
+github.com/bogdanfinn/quic-go-utls v1.0.8-utls h1:IejU2fffVdZZcs23SfGH1b2wzm2G4iNIsYdCBKAbNbI=
+github.com/bogdanfinn/quic-go-utls v1.0.8-utls/go.mod h1:iTKq9gZgFv5YBGmdjuo8Gy0fMzDoqEixu6T5V8fVxZg=
 github.com/bogdanfinn/utls v1.7.7-barnius h1:OuJ497cc7F3yKNVHRsYPQdGggmk5x6+V5ZlrCR7fOLU=
 github.com/bogdanfinn/utls v1.7.7-barnius/go.mod h1:aAK1VZQlpKZClF1WEQeq6kyclbkPq4hz6xTbB5xSlmg=
 github.com/bogdanfinn/websocket v1.5.4-barnius h1:qn3DU/KMHMNPNnwDCtA/IN3QqmzV98DVsvQkQkxruKw=

--- a/mapper.go
+++ b/mapper.go
@@ -18,6 +18,13 @@ var H2SettingsMap = map[string]http2.SettingID{
 	"UNKNOWN_SETTING_9":      0x9,
 }
 
+var H3SettingsMap = map[string]uint64{
+	"QPACK_MAX_TABLE_CAPACITY": 0x1,
+	"MAX_FIELD_SECTION_SIZE":   0x6,
+	"QPACK_BLOCKED_STREAMS":    0x7,
+	"H3_DATAGRAM":              0x33,
+}
+
 var tlsVersions = map[string]uint16{
 	"GREASE": tls.GREASE_PLACEHOLDER,
 	"1.3":    tls.VersionTLS13,

--- a/profiles/contributed_browser_profiles.go
+++ b/profiles/contributed_browser_profiles.go
@@ -144,6 +144,30 @@ var Firefox_147 = ClientProfile{
 		Exclusive: false,
 		Weight:    41,
 	},
+	http3Settings: map[uint64]uint64{
+		1:         65536, // QPACK_MAX_TABLE_CAPACITY
+		7:         20,    // QPACK_BLOCKED_STREAMS
+		727725890: 0,     // Reserved/GREASE setting
+		16765559:  1,     // Reserved/GREASE setting
+		0x33:      1,     // H3_DATAGRAM (51)
+		8:         1,     // Unknown setting (possibly ENABLE_CONNECT_PROTOCOL)
+	},
+	http3SettingsOrder: []uint64{
+		1,         // QPACK_MAX_TABLE_CAPACITY
+		7,         // QPACK_BLOCKED_STREAMS
+		727725890, // Reserved/GREASE setting
+		16765559,  // Reserved/GREASE setting
+		0x33,      // H3_DATAGRAM
+		8,         // Unknown setting
+	},
+	http3PseudoHeaderOrder: []string{
+		":method",
+		":scheme",
+		":authority",
+		":path",
+	},
+	http3PriorityParam:    0,
+	http3SendGreaseFrames: true,
 }
 
 var Firefox_147_PSK = ClientProfile{
@@ -279,6 +303,30 @@ var Firefox_147_PSK = ClientProfile{
 		Exclusive: false,
 		Weight:    41,
 	},
+	http3Settings: map[uint64]uint64{
+		1:         65536, // QPACK_MAX_TABLE_CAPACITY
+		7:         20,    // QPACK_BLOCKED_STREAMS
+		727725890: 0,     // Reserved/GREASE setting
+		16765559:  1,     // Reserved/GREASE setting
+		0x33:      1,     // H3_DATAGRAM (51)
+		8:         1,     // Unknown setting (possibly ENABLE_CONNECT_PROTOCOL)
+	},
+	http3SettingsOrder: []uint64{
+		1,         // QPACK_MAX_TABLE_CAPACITY
+		7,         // QPACK_BLOCKED_STREAMS
+		727725890, // Reserved/GREASE setting
+		16765559,  // Reserved/GREASE setting
+		0x33,      // H3_DATAGRAM
+		8,         // Unknown setting
+	},
+	http3PseudoHeaderOrder: []string{
+		":method",
+		":scheme",
+		":authority",
+		":path",
+	},
+	http3PriorityParam:    0,
+	http3SendGreaseFrames: true,
 }
 
 var Firefox_146_PSK = ClientProfile{

--- a/profiles/internal_browser_profiles.go
+++ b/profiles/internal_browser_profiles.go
@@ -113,6 +113,24 @@ var Chrome_144_PSK = ClientProfile{
 		":path",
 	},
 	connectionFlow: 15663105,
+	http3Settings: map[uint64]uint64{
+		1: 65536, // SETTINGS_QPACK_MAX_TABLE_CAPACITY
+		7: 100,   // SETTINGS_QPACK_BLOCKED_STREAMS
+	},
+	http3SettingsOrder: []uint64{
+		1,    // SETTINGS_QPACK_MAX_TABLE_CAPACITY
+		0x6,  // SETTINGS_MAX_FIELD_SECTION_SIZE
+		7,    // SETTINGS_QPACK_BLOCKED_STREAMS
+		0x33, // SETTINGS_H3_DATAGRAM
+	},
+	http3PriorityParam: 984832,
+	http3PseudoHeaderOrder: []string{
+		":method",
+		":authority",
+		":scheme",
+		":path",
+	},
+	http3SendGreaseFrames: true,
 }
 
 var Chrome_144 = ClientProfile{
@@ -222,6 +240,24 @@ var Chrome_144 = ClientProfile{
 		":path",
 	},
 	connectionFlow: 15663105,
+	http3Settings: map[uint64]uint64{
+		1: 65536, // SETTINGS_QPACK_MAX_TABLE_CAPACITY
+		7: 100,   // SETTINGS_QPACK_BLOCKED_STREAMS
+	},
+	http3SettingsOrder: []uint64{
+		1,    // SETTINGS_QPACK_MAX_TABLE_CAPACITY
+		0x6,  // SETTINGS_MAX_FIELD_SECTION_SIZE
+		7,    // SETTINGS_QPACK_BLOCKED_STREAMS
+		0x33, // SETTINGS_H3_DATAGRAM
+	},
+	http3PriorityParam: 984832,
+	http3PseudoHeaderOrder: []string{
+		":method",
+		":authority",
+		":scheme",
+		":path",
+	},
+	http3SendGreaseFrames: true,
 }
 
 var Chrome_133_PSK = ClientProfile{

--- a/profiles/internal_custom_profiles.go
+++ b/profiles/internal_custom_profiles.go
@@ -102,7 +102,7 @@ func getMMSClientProfile2() ClientProfile {
 		":authority",
 	}
 
-	return NewClientProfile(clientHelloId, settings, settingsOrder, pseudoHeaderOrder, 15663105, nil, nil, 0, false)
+	return NewClientProfile(clientHelloId, settings, settingsOrder, pseudoHeaderOrder, 15663105, nil, nil, 0, false, nil, nil, 0, nil, false)
 }
 
 var MMSIos3 = getMMSClientProfile3()
@@ -209,5 +209,5 @@ func getMMSClientProfile3() ClientProfile {
 		":authority",
 	}
 
-	return NewClientProfile(clientHelloId, settings, settingsOrder, pseudoHeaderOrder, 15663105, nil, nil, 0, false)
+	return NewClientProfile(clientHelloId, settings, settingsOrder, pseudoHeaderOrder, 15663105, nil, nil, 0, false, nil, nil, 0, nil, false)
 }

--- a/profiles/profiles.go
+++ b/profiles/profiles.go
@@ -84,30 +84,38 @@ var MappedTLSClients = map[string]ClientProfile{
 }
 
 type ClientProfile struct {
-	clientHelloId     tls.ClientHelloID
-	headerPriority    *http2.PriorityParam
-	settings          map[http2.SettingID]uint32
-	priorities        []http2.Priority
-	pseudoHeaderOrder []string
-	settingsOrder     []http2.SettingID
-	connectionFlow    uint32
-	// [ADD THESE FIELDS]
-	streamID  uint32
-	allowHTTP bool
+	clientHelloId          tls.ClientHelloID
+	headerPriority         *http2.PriorityParam
+	settings               map[http2.SettingID]uint32
+	settingsOrder          []http2.SettingID
+	priorities             []http2.Priority
+	pseudoHeaderOrder      []string
+	connectionFlow         uint32
+	streamID               uint32
+	allowHTTP              bool
+	http3Settings          map[uint64]uint64
+	http3SettingsOrder     []uint64
+	http3PriorityParam     uint32
+	http3PseudoHeaderOrder []string
+	http3SendGreaseFrames  bool
 }
 
-func NewClientProfile(clientHelloId tls.ClientHelloID, settings map[http2.SettingID]uint32, settingsOrder []http2.SettingID, pseudoHeaderOrder []string, connectionFlow uint32, priorities []http2.Priority, headerPriority *http2.PriorityParam, streamID uint32, allowHTTP bool) ClientProfile {
+func NewClientProfile(clientHelloId tls.ClientHelloID, settings map[http2.SettingID]uint32, settingsOrder []http2.SettingID, pseudoHeaderOrder []string, connectionFlow uint32, priorities []http2.Priority, headerPriority *http2.PriorityParam, streamID uint32, allowHTTP bool, http3Settings map[uint64]uint64, http3SettingsOrder []uint64, http3PriorityParam uint32, http3PseudoHeaderOrder []string, http3SendGreaseFrames bool) ClientProfile {
 	return ClientProfile{
-		clientHelloId:     clientHelloId,
-		settings:          settings,
-		settingsOrder:     settingsOrder,
-		pseudoHeaderOrder: pseudoHeaderOrder,
-		connectionFlow:    connectionFlow,
-		priorities:        priorities,
-		headerPriority:    headerPriority,
-		// [ASSIGN THEM]
-		streamID:  streamID,
-		allowHTTP: allowHTTP,
+		clientHelloId:          clientHelloId,
+		settings:               settings,
+		settingsOrder:          settingsOrder,
+		pseudoHeaderOrder:      pseudoHeaderOrder,
+		connectionFlow:         connectionFlow,
+		priorities:             priorities,
+		headerPriority:         headerPriority,
+		streamID:               streamID,
+		allowHTTP:              allowHTTP,
+		http3Settings:          http3Settings,
+		http3SettingsOrder:     http3SettingsOrder,
+		http3PriorityParam:     http3PriorityParam,
+		http3PseudoHeaderOrder: http3PseudoHeaderOrder,
+		http3SendGreaseFrames:  http3SendGreaseFrames,
 	}
 }
 
@@ -153,4 +161,24 @@ func (c ClientProfile) GetStreamID() uint32 {
 
 func (c ClientProfile) GetAllowHTTP() bool {
 	return c.allowHTTP
+}
+
+func (c ClientProfile) GetHttp3Settings() map[uint64]uint64 {
+	return c.http3Settings
+}
+
+func (c ClientProfile) GetHttp3SettingsOrder() []uint64 {
+	return c.http3SettingsOrder
+}
+
+func (c ClientProfile) GetHttp3PriorityParam() uint32 {
+	return c.http3PriorityParam
+}
+
+func (c ClientProfile) GetHttp3PseudoHeaderOrder() []string {
+	return c.http3PseudoHeaderOrder
+}
+
+func (c ClientProfile) GetHttp3SendGreaseFrames() bool {
+	return c.http3SendGreaseFrames
 }

--- a/tests/http3_chrome_cloudflare_test.go
+++ b/tests/http3_chrome_cloudflare_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestHTTP3WithChromeOnCloudflare(t *testing.T) {
 	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithClientProfile(profiles.Chrome_144),
 		tls_client.WithProtocolRacing(),
 	}
 
@@ -45,7 +45,7 @@ func TestHTTP3WithChromeOnCloudflare(t *testing.T) {
 
 func TestHTTP2WithChromeOnCloudflare(t *testing.T) {
 	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithClientProfile(profiles.Chrome_144),
 		// tls_client.WithProtocolRacing(), // we explicitly disable racing and stick to the "old" behavior
 	}
 

--- a/tests/http3_fingerprint_test.go
+++ b/tests/http3_fingerprint_test.go
@@ -1,0 +1,199 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+	tls_client "github.com/bogdanfinn/tls-client"
+	"github.com/bogdanfinn/tls-client/profiles"
+)
+
+type BrowserLeaksResponse struct {
+	H3Hash string `json:"h3_hash"`
+	H3Text string `json:"h3_text"`
+}
+
+func TestHTTP3FingerprintChrome443(t *testing.T) {
+	options := []tls_client.HttpClientOption{
+		tls_client.WithClientProfile(profiles.Chrome_144),
+		tls_client.WithTimeoutSeconds(30),
+		tls_client.WithProtocolRacing(),
+	}
+
+	client, err := tls_client.NewHttpClient(nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://quic.browserleaks.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header = http.Header{
+		"accept":          {"*/*"},
+		"accept-language": {"en-US,en;q=0.9"},
+		"user-agent":      {"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"},
+		http.HeaderOrderKey: {
+			"accept",
+			"accept-language",
+			"user-agent",
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var browserLeaksResp BrowserLeaksResponse
+	if err := json.Unmarshal(body, &browserLeaksResp); err != nil {
+		t.Logf("JSON unmarshal error: %v", err)
+		t.Fatal(err)
+	}
+
+	expectedH3Hash := "ba909fc3dc419ea5c5b26c6323ac1879"
+	expectedH3Text := "1:65536;6:262144;7:100;51:1;GREASE|GREASE|984832|m,a,s,p"
+
+	if browserLeaksResp.H3Hash != expectedH3Hash {
+		t.Errorf("Chrome_144 HTTP/3 hash mismatch.\nexpected: %s\nactual  : %s", expectedH3Hash, browserLeaksResp.H3Hash)
+	}
+
+	if browserLeaksResp.H3Text != expectedH3Text {
+		t.Errorf("Chrome_144 HTTP/3 fingerprint mismatch.\nexpected: %s\nactual  : %s", expectedH3Text, browserLeaksResp.H3Text)
+	}
+
+	t.Logf("Chrome_144 HTTP/3 fingerprint: %s", browserLeaksResp.H3Text)
+	t.Logf("Chrome_144 HTTP/3 hash: %s", browserLeaksResp.H3Hash)
+}
+
+func TestHTTP3FingerprintFirefox135(t *testing.T) {
+	options := []tls_client.HttpClientOption{
+		tls_client.WithClientProfile(profiles.Firefox_147),
+		tls_client.WithTimeoutSeconds(30),
+		tls_client.WithProtocolRacing(),
+		tls_client.WithTransportOptions(&tls_client.TransportOptions{
+			MaxResponseHeaderBytes: -1, // Firefox doesn't send SETTINGS_MAX_FIELD_SECTION_SIZE
+		}),
+	}
+
+	client, err := tls_client.NewHttpClient(nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://quic.browserleaks.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header = http.Header{
+		"accept":          {"*/*"},
+		"accept-language": {"en-US,en;q=0.9"},
+		"user-agent":      {"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0"},
+		http.HeaderOrderKey: {
+			"accept",
+			"accept-language",
+			"user-agent",
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var browserLeaksResp BrowserLeaksResponse
+	if err := json.Unmarshal(body, &browserLeaksResp); err != nil {
+		t.Logf("JSON unmarshal error: %v", err)
+		t.Fatal(err)
+	}
+
+	expectedH3Hash := "d50d4e585c22bb92b6c86b592aa2d586"
+	expectedH3Text := "1:65536;7:20;727725890:0;16765559:1;51:1;8:1|GREASE|m,s,a,p"
+
+	if browserLeaksResp.H3Hash != expectedH3Hash {
+		t.Errorf("Firefox_147 HTTP/3 hash mismatch.\nexpected: %s\nactual  : %s", expectedH3Hash, browserLeaksResp.H3Hash)
+	}
+
+	if browserLeaksResp.H3Text != expectedH3Text {
+		t.Errorf("Firefox_147 HTTP/3 fingerprint mismatch.\nexpected: %s\nactual  : %s", expectedH3Text, browserLeaksResp.H3Text)
+	}
+
+	t.Logf("Firefox_147 HTTP/3 fingerprint: %s", browserLeaksResp.H3Text)
+	t.Logf("Firefox_147 HTTP/3 hash: %s", browserLeaksResp.H3Hash)
+}
+
+func TestHTTP3FingerprintWithDefaultValuesForChrome(t *testing.T) {
+	options := []tls_client.HttpClientOption{
+		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithTimeoutSeconds(30),
+		tls_client.WithProtocolRacing(),
+	}
+
+	client, err := tls_client.NewHttpClient(nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://quic.browserleaks.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header = http.Header{
+		"accept":          {"*/*"},
+		"accept-language": {"en-US,en;q=0.9"},
+		"user-agent":      {"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"},
+		http.HeaderOrderKey: {
+			"accept",
+			"accept-language",
+			"user-agent",
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var browserLeaksResp BrowserLeaksResponse
+	if err := json.Unmarshal(body, &browserLeaksResp); err != nil {
+		t.Logf("JSON unmarshal error: %v", err)
+		t.Fatal(err)
+	}
+
+	expectedH3Hash := "5d290f560382da8cfd5d89b4f7c8bbe0"
+	expectedH3Text := "6:262144;51:1|m,a,s,p"
+
+	if browserLeaksResp.H3Hash != expectedH3Hash {
+		t.Errorf("Chrome_133 HTTP/3 hash mismatch.\nexpected: %s\nactual  : %s", expectedH3Hash, browserLeaksResp.H3Hash)
+	}
+
+	if browserLeaksResp.H3Text != expectedH3Text {
+		t.Errorf("Chrome_133 HTTP/3 fingerprint mismatch.\nexpected: %s\nactual  : %s", expectedH3Text, browserLeaksResp.H3Text)
+	}
+
+	t.Logf("Chrome_133 HTTP/3 fingerprint: %s", browserLeaksResp.H3Text)
+	t.Logf("Chrome_133 HTTP/3 hash: %s", browserLeaksResp.H3Hash)
+}

--- a/tests/http3_roundtripper_path_test.go
+++ b/tests/http3_roundtripper_path_test.go
@@ -1,0 +1,98 @@
+package tests
+
+import (
+	"io"
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+	tls_client "github.com/bogdanfinn/tls-client"
+	"github.com/bogdanfinn/tls-client/profiles"
+)
+
+func TestHTTP3DirectPathChrome(t *testing.T) {
+	options := []tls_client.HttpClientOption{
+		tls_client.WithClientProfile(profiles.Chrome_144),
+		tls_client.WithTimeoutSeconds(30),
+		// NO WithProtocolRacing() - forces direct ALPN path via roundtripper.go
+	}
+
+	client, err := tls_client.NewHttpClient(nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://quic.browserleaks.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header = http.Header{
+		"accept":          {"*/*"},
+		"accept-language": {"en-US,en;q=0.9"},
+		"user-agent":      {"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"},
+		http.HeaderOrderKey: {
+			"accept",
+			"accept-language",
+			"user-agent",
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	expectedH3Hash := "ba909fc3dc419ea5c5b26c6323ac1879"
+
+	t.Logf("Chrome_144 HTTP/3 direct path test completed")
+	t.Logf("Expected hash: %s", expectedH3Hash)
+	t.Logf("Protocol used: %s", resp.Proto)
+}
+
+func TestHTTP3DirectPathFirefox(t *testing.T) {
+	options := []tls_client.HttpClientOption{
+		tls_client.WithClientProfile(profiles.Firefox_147),
+		tls_client.WithTimeoutSeconds(30),
+		// NO WithProtocolRacing() - forces direct ALPN path via roundtripper.go
+		tls_client.WithTransportOptions(&tls_client.TransportOptions{
+			MaxResponseHeaderBytes: -1, // Firefox doesn't send SETTINGS_MAX_FIELD_SECTION_SIZE
+		}),
+	}
+
+	client, err := tls_client.NewHttpClient(nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://quic.browserleaks.com/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header = http.Header{
+		"accept":          {"*/*"},
+		"accept-language": {"en-US,en;q=0.9"},
+		"user-agent":      {"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:135.0) Gecko/20100101 Firefox/135.0"},
+		http.HeaderOrderKey: {
+			"accept",
+			"accept-language",
+			"user-agent",
+		},
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// Verify the fingerprint matches Firefox expectations
+	expectedH3Hash := "d50d4e585c22bb92b6c86b592aa2d586"
+
+	t.Logf("Firefox_147 HTTP/3 direct path test completed")
+	t.Logf("Expected hash: %s", expectedH3Hash)
+	t.Logf("Protocol used: %s", resp.Proto)
+}

--- a/tests/http3_test.go
+++ b/tests/http3_test.go
@@ -12,8 +12,9 @@ import (
 
 func TestHTTP3(t *testing.T) {
 	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithClientProfile(profiles.Chrome_144),
 		tls_client.WithTimeoutSeconds(30),
+		tls_client.WithProtocolRacing(),
 		tls_client.WithDebug(),
 	}
 
@@ -46,7 +47,7 @@ func TestHTTP3(t *testing.T) {
 
 func TestDisableHTTP3(t *testing.T) {
 	options := []tls_client.HttpClientOption{
-		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithClientProfile(profiles.Chrome_144),
 		tls_client.WithTimeoutSeconds(30),
 		tls_client.WithDisableHttp3(),
 		tls_client.WithDebug(),

--- a/utils.go
+++ b/utils.go
@@ -1,8 +1,11 @@
 package tls_client
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"math"
+	"math/big"
 )
 
 func Int64ToInt(x int64) (int, error) {
@@ -10,4 +13,27 @@ func Int64ToInt(x int64) (int, error) {
 		return 0, fmt.Errorf("int64 value %d out of int range [%d, %d]", x, math.MinInt, math.MaxInt)
 	}
 	return int(x), nil
+}
+
+// generateGREASESettingID generates a valid GREASE setting ID
+// GREASE IDs are of the form 0x1f * N + 0x21 where N is random
+// Chrome uses very large N values, producing setting IDs like 57836956465
+func generateGREASESettingID() uint64 {
+	// Generate large N values similar to Chrome (produces 10-11 digit IDs)
+	// N between 1,000,000,000 and 10,000,000,000
+	nBig, _ := rand.Int(rand.Reader, big.NewInt(9000000000))
+	n := uint64(1000000000) + nBig.Uint64()
+	return 0x1f*n + 0x21
+}
+
+// generateGREASESettingValue generates a random non-zero 32-bit value for GREASE
+func generateGREASESettingValue() uint64 {
+	var buf [4]byte
+	rand.Read(buf[:])
+	val := binary.BigEndian.Uint32(buf[:])
+	// Chrome never sends 0
+	if val == 0 {
+		val = 1
+	}
+	return uint64(val)
 }


### PR DESCRIPTION
    - Implement correct Chrome 144 HTTP/3 fingerprint with PRIORITY_UPDATE frame (984832)
    - Implement correct Firefox 147 HTTP/3 fingerprint without SETTINGS_MAX_FIELD_SECTION_SIZE
    - Add GREASE frames and random GREASE settings (Chrome only)
    - Fix MaxResponseHeaderBytes handling (-1 for Firefox, positive values for Chrome)
    - Add HTTP/3 protocol racing support
    - All HTTP/3 fingerprint tests passing