### PR TITLE
fixed websocket connection;

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,6 +57,7 @@ type HttpClient interface {
 
     GetBandwidthTracker() bandwidth.BandwidthTracker
     GetDialer() proxy.ContextDialer
+    GetTLSDialer() TLSDialerFunc
 }
 ```
 
@@ -83,7 +84,7 @@ func main() {
 	jar := tls_client.NewCookieJar()
 	options := []tls_client.HttpClientOption{
 		tls_client.WithTimeoutSeconds(30),
-		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithClientProfile(profiles.Chrome_144),
 		tls_client.WithNotFollowRedirects(),
 		tls_client.WithCookieJar(jar), // create cookieJar instance and pass it as argument
 	}

--- a/websocket.go
+++ b/websocket.go
@@ -54,7 +54,7 @@ func NewWebsocket(logger Logger, options ...WebsocketOption) (*Websocket, error)
 		Jar:               config.cookieJar,
 		ReadBufferSize:    config.readBufferSize,
 		WriteBufferSize:   config.writeBufferSize,
-		NetDialTLSContext: config.tlsClient.GetDialer().DialContext,
+		NetDialTLSContext: config.tlsClient.GetTLSDialer(),
 		NetDialContext:    config.tlsClient.GetDialer().DialContext,
 	}
 


### PR DESCRIPTION
WebSocket uTLS:
- Add GetTLSDialer() to use same fingerprinting as HTTP
- Add dialTLSForWebsocket() method for WebSocket connections
- Fix WebSocket to work with real servers (echo.websocket.org)