### PR TITLE
fix: isByteResponse returns empty body in BuildResponse after #232

### DIFF
--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -216,34 +216,38 @@ func BuildResponse(sessionId string, withSession bool, resp *http.Response, cook
 
 	bodyReader = resp.Body
 
-	if !isByteResponse {
-		// Try to preview a single byte of the body reader to prevent EOF caused by empty bodies.
-		// This is probably the best way of reliably detecting empty response bodies,
-		// especially when the content-length response header is not present.
-		firstByte := make([]byte, 1)
-		n, err := io.ReadFull(resp.Body, firstByte)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return Response{}, NewTLSClientError(err)
-		}
+	// Preview a single byte of the body first so we can cleanly return an
+	// empty body without letting charset.NewReader's auto-detection raise
+	// EOF on zero-length responses (the guard from #232). The peeked byte is
+	// stitched back on via io.MultiReader before the body is consumed.
+	// Both byte and non-byte responses need to read the body here; charset
+	// detection is only applied below when !isByteResponse.
+	firstByte := make([]byte, 1)
+	n, err := io.ReadFull(resp.Body, firstByte)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return Response{}, NewTLSClientError(err)
+	}
 
-		if n == 0 {
-			respBodyBytes = nil
-		} else {
-			bodyReader = io.MultiReader(bytes.NewReader(firstByte[:n]), resp.Body)
+	if n == 0 {
+		respBodyBytes = nil
+	} else {
+		bodyReader = io.MultiReader(bytes.NewReader(firstByte[:n]), resp.Body)
+
+		if !isByteResponse {
 			// Automatically detect the charset for non-byte responses
 			bodyReader, err = charset.NewReader(bodyReader, ct)
 			if err != nil {
 				return Response{}, NewTLSClientError(err)
 			}
+		}
 
-			if input.StreamOutputPath != nil {
-				respBodyBytes, err = readAllBodyWithStreamToFile(bodyReader, input)
-			} else {
-				respBodyBytes, err = io.ReadAll(bodyReader)
-			}
-			if err != nil {
-				return Response{}, NewTLSClientError(err)
-			}
+		if input.StreamOutputPath != nil {
+			respBodyBytes, err = readAllBodyWithStreamToFile(bodyReader, input)
+		} else {
+			respBodyBytes, err = io.ReadAll(bodyReader)
+		}
+		if err != nil {
+			return Response{}, NewTLSClientError(err)
 		}
 	}
 

--- a/cffi_src/factory_test.go
+++ b/cffi_src/factory_test.go
@@ -1,0 +1,136 @@
+package tls_client_cffi_src
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+	"github.com/bogdanfinn/fhttp/httptest"
+)
+
+// TestBuildResponse_IsByteResponse_NonEmptyBody guards against the regression
+// where isByteResponse=true returned an empty base64 payload because
+// io.ReadAll was scoped to the !isByteResponse branch.
+func TestBuildResponse_IsByteResponse_NonEmptyBody(t *testing.T) {
+	want := []byte{0x00, 0x01, 0x02, 0x03, 0xFF, 0x80, 0x7F}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(want)
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+
+	out, cErr := BuildResponse("", false, resp, nil, RequestInput{IsByteResponse: true})
+	if cErr != nil {
+		t.Fatalf("BuildResponse: %v", cErr)
+	}
+
+	const prefix = "data:"
+	if !strings.HasPrefix(out.Body, prefix) {
+		t.Fatalf("expected data URI prefix, got %q", out.Body)
+	}
+	commaIdx := strings.Index(out.Body, ",")
+	if commaIdx == -1 {
+		t.Fatalf("expected comma separator in data URI, got %q", out.Body)
+	}
+	b64 := out.Body[commaIdx+1:]
+	if b64 == "" {
+		t.Fatalf("byte-response payload is empty; body = %q", out.Body)
+	}
+	got, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("bytes mismatch: want %x, got %x", want, got)
+	}
+}
+
+// TestBuildResponse_IsByteResponse_EmptyBody covers the edge case of an empty
+// body with isByteResponse=true. The result should be a data URI whose payload
+// is an empty base64 string; it should not error.
+func TestBuildResponse_IsByteResponse_EmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+
+	out, cErr := BuildResponse("", false, resp, nil, RequestInput{IsByteResponse: true})
+	if cErr != nil {
+		t.Fatalf("BuildResponse: %v", cErr)
+	}
+
+	commaIdx := strings.Index(out.Body, ",")
+	if commaIdx == -1 {
+		t.Fatalf("expected comma separator in data URI, got %q", out.Body)
+	}
+	if out.Body[commaIdx+1:] != "" {
+		t.Fatalf("expected empty base64 payload, got %q", out.Body[commaIdx+1:])
+	}
+}
+
+// TestBuildResponse_TextResponse_EmptyBody covers the case #232 originally
+// fixed: a zero-length text response should not trip charset.NewReader into
+// raising EOF; it should return an empty body cleanly.
+func TestBuildResponse_TextResponse_EmptyBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("Content-Length", "0")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+
+	out, cErr := BuildResponse("", false, resp, nil, RequestInput{IsByteResponse: false})
+	if cErr != nil {
+		t.Fatalf("BuildResponse: %v", cErr)
+	}
+	if out.Body != "" {
+		t.Fatalf("expected empty body, got %q", out.Body)
+	}
+}
+
+// TestBuildResponse_TextResponse_NonEmptyBody checks the common text path
+// still works: charset detection decodes and returns the body as-is.
+func TestBuildResponse_TextResponse_NonEmptyBody(t *testing.T) {
+	const want = "hello, world"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(want))
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+
+	out, cErr := BuildResponse("", false, resp, nil, RequestInput{IsByteResponse: false})
+	if cErr != nil {
+		t.Fatalf("BuildResponse: %v", cErr)
+	}
+	if out.Body != want {
+		t.Fatalf("body mismatch: want %q, got %q", want, out.Body)
+	}
+}


### PR DESCRIPTION
## Bug

`BuildResponse` never reads the response body when `isByteResponse=true`, producing an empty payload wrapped in a `text/plain` data URI regardless of the actual response content.

Repro:

```go
srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
    w.Header().Set("Content-Type", "application/octet-stream")
    w.Write([]byte{0x00, 0x01, 0x02, 0x03, 0xFF})
}))
defer srv.Close()

resp, _ := http.Get(srv.URL)
out, _ := BuildResponse("", false, resp, nil, RequestInput{IsByteResponse: true})
fmt.Println(out.Body)
```

**Actual:** `data:text/plain; charset=utf-8;base64,`
**Expected:** `data:application/octet-stream;base64,AAECA/8=`

## Root cause

#232 (commit `d0fc595`, _"fix EOF errors caused by the charset reader by previewing the response body whether at least one byte exists"_) added a first-byte preview + `io.MultiReader` + `io.ReadAll` to guard against `charset.NewReader` raising EOF on zero-length text bodies. The block — _including_ the `io.ReadAll` — was placed inside `if !isByteResponse`:

```go
if !isByteResponse {
    firstByte := make([]byte, 1)
    n, err := io.ReadFull(resp.Body, firstByte)
    // ...
    if n == 0 {
        respBodyBytes = nil
    } else {
        bodyReader = io.MultiReader(bytes.NewReader(firstByte[:n]), resp.Body)
        bodyReader, err = charset.NewReader(bodyReader, ct)
        // ...
        respBodyBytes, err = io.ReadAll(bodyReader)
    }
}
```

So when `isByteResponse=true`, that entire block is skipped. `respBodyBytes` is never populated; the body is never read. Downstream:

```go
mimeType := http.DetectContentType(respBodyBytes)   // "text/plain; charset=utf-8"
base64.StdEncoding.EncodeToString(respBodyBytes)    // ""
```

which is exactly the string I see in the repro above.

I think the intent of #232 was to gate _charset detection_ behind `!isByteResponse` (because charset sniffing is only meaningful for text responses), but the patch ended up gating _the whole read_ behind that branch.

## Fix

Hoist the peek + `io.ReadAll` out of the conditional so both paths read the body. Keep `charset.NewReader` inside `!isByteResponse`. The empty-body guard from #232 is preserved via the `n == 0` short-circuit, which runs before either path.

```go
firstByte := make([]byte, 1)
n, err := io.ReadFull(resp.Body, firstByte)
if err != nil && !errors.Is(err, io.EOF) {
    return Response{}, NewTLSClientError(err)
}

if n == 0 {
    respBodyBytes = nil
} else {
    bodyReader = io.MultiReader(bytes.NewReader(firstByte[:n]), resp.Body)

    if !isByteResponse {
        // Automatically detect the charset for non-byte responses
        bodyReader, err = charset.NewReader(bodyReader, ct)
        if err != nil {
            return Response{}, NewTLSClientError(err)
        }
    }

    if input.StreamOutputPath != nil {
        respBodyBytes, err = readAllBodyWithStreamToFile(bodyReader, input)
    } else {
        respBodyBytes, err = io.ReadAll(bodyReader)
    }
    if err != nil {
        return Response{}, NewTLSClientError(err)
    }
}
```

## Tests

Added `cffi_src/factory_test.go` with four cases:

| Case | On master | With fix |
|---|---|---|
| `isByteResponse=true` + non-empty binary body | **FAIL** (`byte-response payload is empty`) | PASS |
| `isByteResponse=true` + empty body | PASS | PASS |
| `isByteResponse=false` + empty text body (the #232 case) | PASS | PASS |
| `isByteResponse=false` + non-empty text body | PASS | PASS |

The first one is the regression guard — it fails on current master with the exact symptom described above.

## Scope

One function in `cffi_src/factory.go` plus a new `cffi_src/factory_test.go`. No behavior change for non-byte callers; no change to the `StreamOutputPath` path beyond running in the normalized block. Pre-existing `BuildResponse` callers in `cffi_dist/main.go` unaffected.