### PR TITLE
Streaming response support for the cffi interface + bug fixes

### DIFF
--- a/cffi_dist/example_python/example_stream.py
+++ b/cffi_dist/example_python/example_stream.py
@@ -1,0 +1,184 @@
+"""Streaming response example for the tls-client cffi interface.
+
+The regular `request` export reads the entire response body before returning,
+which makes it unsuitable for server-sent events, NDJSON feeds, or any other
+long-lived response where the caller needs to react to bytes as they arrive.
+
+This example demonstrates the four streaming exports that solve that:
+
+    requestStream  -> send the request, get back the response *headers*
+                      (and a streamId) as soon as they arrive; the body keeps
+                      flowing into a per-stream buffer on the Go side.
+    readStream     -> poll one chunk at a time, with a heartbeat timeout so
+                      the loop can check for cancellation without ever
+                      blocking forever.
+    readStreamAll  -> alternative: drain the rest of the body in one call
+                      and get a normal Response envelope (used when the
+                      response turns out NOT to be streaming after all).
+    cancelStream   -> tear down a stream early; idempotent, safe in finally.
+
+The script issues a streaming request to httpbin.org/stream/5, reassembles
+\\n-terminated JSON events across TCP chunk boundaries, prints each one as
+it arrives, and cleans up via cancelStream. Swap the URL for a real SSE
+endpoint and the same loop works unchanged — only the framing parser would
+extend from "split on \\n" to "split on \\n\\n event boundaries".
+"""
+
+import ctypes
+import json
+import base64
+
+# load the tls-client shared package for your OS you are currently running your python script (i'm running on mac)
+library = ctypes.cdll.LoadLibrary('./../dist/tls-client-darwin-amd64-1.7.2.dylib')
+
+# request / freeMemory work as in the other examples; freeMemory is reused
+# below to release every JSON envelope returned by the streaming exports.
+freeMemory = library.freeMemory
+freeMemory.argtypes = [ctypes.c_char_p]
+
+# The four streaming exports introduced for SSE / chunked-body consumption.
+# All take a JSON payload and return a *char to a JSON envelope; the caller
+# must always call freeMemory(envelope.id) when done with the returned string.
+requestStream = library.requestStream
+requestStream.argtypes = [ctypes.c_char_p]
+requestStream.restype = ctypes.c_char_p
+
+readStream = library.readStream
+readStream.argtypes = [ctypes.c_char_p]
+readStream.restype = ctypes.c_char_p
+
+readStreamAll = library.readStreamAll
+readStreamAll.argtypes = [ctypes.c_char_p]
+readStreamAll.restype = ctypes.c_char_p
+
+cancelStream = library.cancelStream
+cancelStream.argtypes = [ctypes.c_char_p]
+cancelStream.restype = ctypes.c_char_p
+
+
+def call(fn, payload):
+    """Invoke a cffi export, parse its JSON, and free the returned C string.
+
+    Every cffi export tracks its returned char* in an internal map keyed by
+    the envelope's "id" field. freeMemory(id) releases that pointer; doing
+    it eagerly keeps the Go-side map small.
+    """
+    raw = fn(json.dumps(payload).encode('utf-8'))
+    envelope = json.loads(ctypes.string_at(raw).decode('utf-8'))
+    if 'id' in envelope:
+        freeMemory(envelope['id'].encode('utf-8'))
+    return envelope
+
+
+# Streaming requests use the same RequestInput shape as the regular `request`
+# export. Two fields matter specifically for streaming:
+#   - streamOutputBlockSize : how many bytes the Go-side pump reads per chunk
+#                             (default 4096)
+#   - timeoutSeconds        : the http.Client timeout wraps the *entire*
+#                             response including body reads, so for long-lived
+#                             SSE streams set it to 0 (no timeout); for finite
+#                             streams a generous value is fine.
+requestPayload = {
+    "tlsClientIdentifier": "chrome_124",
+    "followRedirects": True,
+    "timeoutSeconds": 30,
+    "streamOutputBlockSize": 4096,
+    "headers": {
+        "accept": "application/json",
+        "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        "accept-encoding": "gzip, deflate, br",
+    },
+    "headerOrder": ["accept", "user-agent", "accept-encoding"],
+    # httpbin's /stream/N returns N newline-delimited JSON objects with a
+    # chunked body. The framing isn't strictly SSE (no `data:` prefix), but
+    # the mechanics — many small chunks arriving over time, terminated by
+    # the server closing the body — are identical, which is what this
+    # example demonstrates. For real SSE just point the URL at a server
+    # that emits `text/event-stream`.
+    "requestUrl": "https://httpbin.org/stream/5",
+    "requestMethod": "GET",
+    "requestBody": "",
+    "requestCookies": [],
+}
+
+
+# 1) Kick off the request. requestStream returns once the response *headers*
+#    are in; the body keeps streaming on the Go side into a per-stream buffer
+#    identified by streamId.
+start = call(requestStream, requestPayload)
+if start.get('status', 0) == 0:
+    raise RuntimeError(f"requestStream failed: {start.get('body')}")
+
+stream_id = start['streamId']
+content_type = (start['headers'].get('Content-Type') or [''])[0]
+print(f"status={start['status']} streamId={stream_id} content-type={content_type}")
+
+
+# 2) Now you have a choice based on what the response actually is:
+#
+#       a) For SSE / NDJSON / any chunk-by-chunk consumption, loop readStream.
+#          That's what this example does.
+#
+#       b) If the response turns out NOT to be streaming (e.g. you fired
+#          requestStream but the server returned a plain JSON document),
+#          call readStreamAll once to drain the rest of the body into a
+#          standard Response envelope — same shape as the `request` export.
+#          See drain_all_in_one_call() at the bottom of this file.
+#
+#    Real callers typically branch on Content-Type:
+#        if 'text/event-stream' in content_type or 'ndjson' in content_type:
+#            <loop readStream>
+#        else:
+#            <readStreamAll>
+def stream_chunks_until_eof(stream_id):
+    """Loop readStream and yield reassembled \\n-terminated lines.
+
+    SSE event boundaries are \\n\\n, NDJSON boundaries are \\n; this helper
+    yields per-line and lets the caller decide. Note that one TCP read can
+    deliver multiple lines or part of a line, so we maintain a buffer
+    across iterations.
+    """
+    buffer = b''
+    while True:
+        # timeoutMs is a heartbeat — when no data arrives within that window
+        # readStream returns {timeout: true} so the loop can check for
+        # cancellation without ever blocking forever.
+        chunk_env = call(readStream, {"streamId": stream_id, "timeoutMs": 1000})
+
+        if chunk_env.get('error'):
+            raise RuntimeError(f"stream error: {chunk_env['error']}")
+
+        if chunk_env.get('timeout'):
+            # In a real app: check a cancellation token here.
+            continue
+
+        if chunk_env.get('chunk'):
+            buffer += base64.b64decode(chunk_env['chunk'])
+            while b'\n' in buffer:
+                line, buffer = buffer.split(b'\n', 1)
+                if line.strip():
+                    yield line.decode('utf-8', errors='replace')
+
+        if chunk_env.get('eof'):
+            if buffer.strip():
+                yield buffer.decode('utf-8', errors='replace')
+            return
+
+
+def drain_all_in_one_call(stream_id):
+    """Alternative: when the response turns out to be non-streaming, drain
+    the rest of the body in a single call. Returns the same Response envelope
+    shape as the regular `request` export (status, headers, body, cookies, ...).
+
+    Not used by this demo, but shown for completeness.
+    """
+    return call(readStreamAll, {"streamId": stream_id})
+
+
+# 3) Stream events until EOF, always cleaning up the stream on the way out.
+#    cancelStream is idempotent and safe to call even after a natural EOF.
+try:
+    for i, event in enumerate(stream_chunks_until_eof(stream_id)):
+        print(f"event[{i}]: {event}")
+finally:
+    call(cancelStream, {"streamId": stream_id})

--- a/cffi_dist/example_python/example_stream.py
+++ b/cffi_dist/example_python/example_stream.py
@@ -75,9 +75,13 @@ def call(fn, payload):
 #   - streamOutputBlockSize : how many bytes the Go-side pump reads per chunk
 #                             (default 4096)
 #   - timeoutSeconds        : the http.Client timeout wraps the *entire*
-#                             response including body reads, so for long-lived
-#                             SSE streams set it to 0 (no timeout); for finite
-#                             streams a generous value is fine.
+#                             response including body reads. For long-lived
+#                             SSE streams pass a NEGATIVE value (e.g. -1) to
+#                             disable the deadline; 0 means "use the 30 s
+#                             default" because the cffi cannot distinguish
+#                             "field omitted" from "field set to 0".
+#                             For finite streams a generous positive value
+#                             is fine.
 requestPayload = {
     "tlsClientIdentifier": "chrome_124",
     "followRedirects": True,

--- a/cffi_dist/main.go
+++ b/cffi_dist/main.go
@@ -6,6 +6,7 @@ package main
 import "C"
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -43,6 +44,7 @@ func freeMemory(responseId *C.char) {
 //export destroyAll
 func destroyAll() *C.char {
 	tls_client_cffi_src.ClearSessionCache()
+	tls_client_cffi_src.ClearStreamCache()
 
 	out := tls_client_cffi_src.DestroyOutput{
 		Id:      uuid.New().String(),
@@ -275,6 +277,178 @@ func request(requestParams *C.char) *C.char {
 
 	unsafePointersLck.Lock()
 	unsafePointers[response.Id] = responseString
+	unsafePointersLck.Unlock()
+
+	return responseString
+}
+
+//export requestStream
+func requestStream(requestParams *C.char) *C.char {
+	requestParamsJson := C.GoString(requestParams)
+
+	requestInput := tls_client_cffi_src.RequestInput{}
+	marshallError := json.Unmarshal([]byte(requestParamsJson), &requestInput)
+
+	if marshallError != nil {
+		clientErr := tls_client_cffi_src.NewTLSClientError(marshallError)
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	tlsClient, sessionId, withSession, err := tls_client_cffi_src.CreateClient(requestInput)
+	if err != nil {
+		return handleErrorResponse(sessionId, withSession, err)
+	}
+
+	req, err := tls_client_cffi_src.BuildRequest(requestInput)
+	if err != nil {
+		return handleErrorResponse(sessionId, withSession, err)
+	}
+
+	// Cancellable context so cancelStream can release the in-flight read.
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+
+	cookies := buildCookies(requestInput.RequestCookies)
+	if tlsClient.GetCookieJar() != nil && len(cookies) > 0 {
+		tlsClient.SetCookies(req.URL, cookies)
+	} else {
+		for _, cookie := range cookies {
+			req.AddCookie(cookie)
+		}
+	}
+
+	resp, reqErr := tlsClient.Do(req)
+	if reqErr != nil {
+		cancel()
+		clientErr := tls_client_cffi_src.NewTLSClientError(fmt.Errorf("failed to do request: %w", reqErr))
+		return handleErrorResponse(sessionId, withSession, clientErr)
+	}
+	if resp == nil {
+		cancel()
+		clientErr := tls_client_cffi_src.NewTLSClientError(fmt.Errorf("response is nil"))
+		return handleErrorResponse(sessionId, withSession, clientErr)
+	}
+
+	targetCookies := tlsClient.GetCookies(resp.Request.URL)
+
+	blockSize := 0
+	if requestInput.StreamOutputBlockSize != nil {
+		blockSize = *requestInput.StreamOutputBlockSize
+	}
+
+	streamId := uuid.New().String()
+	state := tls_client_cffi_src.StartStream(streamId, tls_client_cffi_src.StartStreamParams{
+		Response:       resp,
+		Cookies:        targetCookies,
+		Cancel:         cancel,
+		SessionId:      sessionId,
+		WithSession:    withSession,
+		IsByteResponse: requestInput.IsByteResponse,
+		BlockSize:      blockSize,
+	})
+
+	out := tls_client_cffi_src.BuildStreamStartResponse(streamId, state)
+
+	jsonResponse, marshallError := json.Marshal(out)
+	if marshallError != nil {
+		tls_client_cffi_src.CancelStream(streamId)
+		clientErr := tls_client_cffi_src.NewTLSClientError(marshallError)
+		return handleErrorResponse(sessionId, withSession, clientErr)
+	}
+
+	responseString := C.CString(string(jsonResponse))
+
+	unsafePointersLck.Lock()
+	unsafePointers[out.Id] = responseString
+	unsafePointersLck.Unlock()
+
+	return responseString
+}
+
+//export readStream
+func readStream(readStreamParams *C.char) *C.char {
+	readStreamParamsJson := C.GoString(readStreamParams)
+
+	input := tls_client_cffi_src.ReadStreamInput{}
+	if marshallError := json.Unmarshal([]byte(readStreamParamsJson), &input); marshallError != nil {
+		clientErr := tls_client_cffi_src.NewTLSClientError(marshallError)
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	out := tls_client_cffi_src.ReadStreamChunk(input.StreamId, input.TimeoutMs)
+
+	jsonResponse, marshallError := json.Marshal(out)
+	if marshallError != nil {
+		clientErr := tls_client_cffi_src.NewTLSClientError(marshallError)
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	responseString := C.CString(string(jsonResponse))
+
+	unsafePointersLck.Lock()
+	unsafePointers[out.Id] = responseString
+	unsafePointersLck.Unlock()
+
+	return responseString
+}
+
+//export readStreamAll
+func readStreamAll(readStreamAllParams *C.char) *C.char {
+	readStreamAllParamsJson := C.GoString(readStreamAllParams)
+
+	input := tls_client_cffi_src.ReadStreamAllInput{}
+	if marshallError := json.Unmarshal([]byte(readStreamAllParamsJson), &input); marshallError != nil {
+		clientErr := tls_client_cffi_src.NewTLSClientError(marshallError)
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	response, drainErr := tls_client_cffi_src.ReadStreamAll(input.StreamId)
+	if drainErr != nil {
+		return handleErrorResponse("", false, drainErr)
+	}
+
+	jsonResponse, marshallError := json.Marshal(response)
+	if marshallError != nil {
+		clientErr := tls_client_cffi_src.NewTLSClientError(marshallError)
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	responseString := C.CString(string(jsonResponse))
+
+	unsafePointersLck.Lock()
+	unsafePointers[response.Id] = responseString
+	unsafePointersLck.Unlock()
+
+	return responseString
+}
+
+//export cancelStream
+func cancelStream(cancelStreamParams *C.char) *C.char {
+	cancelStreamParamsJson := C.GoString(cancelStreamParams)
+
+	input := tls_client_cffi_src.CancelStreamInput{}
+	if marshallError := json.Unmarshal([]byte(cancelStreamParamsJson), &input); marshallError != nil {
+		clientErr := tls_client_cffi_src.NewTLSClientError(marshallError)
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	tls_client_cffi_src.CancelStream(input.StreamId)
+
+	out := tls_client_cffi_src.DestroyOutput{
+		Id:      uuid.New().String(),
+		Success: true,
+	}
+
+	jsonResponse, marshallError := json.Marshal(out)
+	if marshallError != nil {
+		clientErr := tls_client_cffi_src.NewTLSClientError(marshallError)
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	responseString := C.CString(string(jsonResponse))
+
+	unsafePointersLck.Lock()
+	unsafePointers[out.Id] = responseString
 	unsafePointersLck.Unlock()
 
 	return responseString

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -245,6 +245,19 @@ func BuildResponse(sessionId string, withSession bool, resp *http.Response, cook
 				return Response{}, NewTLSClientError(err)
 			}
 		}
+	} else {
+		// Byte responses skip the charset wrapper / empty-body preview entirely — they are
+		// returned to the caller as raw bytes inside a base64 data URI, so charset decoding
+		// would corrupt the payload.
+		var err error
+		if input.StreamOutputPath != nil {
+			respBodyBytes, err = readAllBodyWithStreamToFile(bodyReader, input)
+		} else {
+			respBodyBytes, err = io.ReadAll(bodyReader)
+		}
+		if err != nil {
+			return Response{}, NewTLSClientError(err)
+		}
 	}
 
 	finalResponse := string(respBodyBytes)

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -335,7 +335,12 @@ func getTlsClient(requestInput RequestInput, sessionId string, withSession bool)
 
 	client, ok := clients[sessionId]
 
-	if ok && withSession {
+	// Bypass the client cache when WithDebug is set so the freshly-built client picks up
+	// the debug logger configured below. Otherwise the cached client (built earlier on
+	// the same session with NewNoopLogger) would silently win and the WithDebug flag
+	// would have no observable effect on the cffi caller. Diagnostic-only path; normal
+	// callers don't pay this cost.
+	if ok && withSession && !requestInput.WithDebug {
 		modifiedClient, changed, err := handleModification(client, proxyUrl, requestInput.FollowRedirects, requestInput.IsRotatingProxy)
 		if err != nil {
 			return nil, fmt.Errorf("failed to modify existing client: %w", err)
@@ -471,7 +476,21 @@ func getTlsClient(requestInput RequestInput, sessionId string, withSession bool)
 		options = append(options, tls_client.WithProxyUrl(*proxy))
 	}
 
-	tlsClient, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), options...)
+	// Honour WithDebug=true at the cffi layer too. tls_client.WithDebug() (added
+	// to options above) already makes NewHttpClient auto-wrap the supplied logger
+	// via NewDebugLogger, which routes Debug() through fmt.Printf. The catch: the
+	// wrapper only overrides Debug() — Info / Warn / Error keep forwarding through
+	// to the wrapped base logger. With a NewNoopLogger() base, diagnostic calls
+	// like c.logger.Warn("you did not setup a cookie jar") and c.logger.Error(
+	// "critical error during request handling") were silently dropped. Switch the
+	// base to NewLogger() so non-Debug levels also reach stdout. The explicit
+	// NewDebugLogger() wrap is belt-and-suspenders: if a future refactor drops
+	// tls_client.WithDebug() from the options chain, Debug() still surfaces.
+	var clientLogger tls_client.Logger = tls_client.NewNoopLogger()
+	if requestInput.WithDebug {
+		clientLogger = tls_client.NewDebugLogger(tls_client.NewLogger())
+	}
+	tlsClient, err := tls_client.NewHttpClient(clientLogger, options...)
 
 	if withSession {
 		clients[sessionId] = tlsClient

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -297,6 +297,44 @@ func BuildResponse(sessionId string, withSession bool, resp *http.Response, cook
 	return response, nil
 }
 
+// SSLKEYLOGFILE is captured exactly once per process. The env var is read
+// and the file is opened on the first call to sslKeyLogWriterFromEnv; both
+// the resolved writer (or nil, if unset / unopenable) are then frozen for
+// the rest of the process lifetime. Doing it this way:
+//
+//   - reads os.Getenv at most once instead of on every getTlsClient call
+//   - shares one append-mode writer across all TLS connections, which is
+//     exactly the contract Wireshark / NSS expect (one master-secret line
+//     per CR/LF, all collated into one file)
+//   - intentionally ignores mid-process changes to SSLKEYLOGFILE — chasing
+//     env mutations would only matter for a debug feature where session
+//     log continuity is more useful than reactivity.
+var (
+	sslKeyLogOnce   sync.Once
+	sslKeyLogWriter io.Writer
+)
+
+// sslKeyLogWriterFromEnv returns the io.Writer attached to SSLKEYLOGFILE, or
+// nil if the env var was unset at first call or the file couldn't be opened.
+// SSLKEYLOGFILE is the convention Chrome, curl, Firefox and Go's standard
+// crypto/tls package use — dropping the same env var that decrypts a desktop
+// app capture is enough to have Wireshark decrypt the cffi caller's TLS too.
+func sslKeyLogWriterFromEnv() io.Writer {
+	sslKeyLogOnce.Do(func() {
+		path := os.Getenv("SSLKEYLOGFILE")
+		if path == "" {
+			return
+		}
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			fmt.Printf("tls-client: failed to open SSLKEYLOGFILE %q: %v\n", path, err)
+			return
+		}
+		sslKeyLogWriter = f
+	})
+	return sslKeyLogWriter
+}
+
 // ResolveTimeoutOption picks the right tls_client timeout option based on the
 // cffi RequestInput timeout fields. The mapping is:
 //
@@ -411,7 +449,20 @@ func getTlsClient(requestInput RequestInput, sessionId string, withSession bool)
 			// RootCAs:                requestInput.TransportOptions.RootCAs,
 		}
 
+		if w := sslKeyLogWriterFromEnv(); w != nil && transportOptions.KeyLogWriter == nil {
+			transportOptions.KeyLogWriter = w
+		}
 		options = append(options, tls_client.WithTransportOptions(transportOptions))
+	} else if w := sslKeyLogWriterFromEnv(); w != nil {
+		// Honour SSLKEYLOGFILE even when the caller didn't pass TransportOptions —
+		// avoids forcing every cffi consumer to construct an empty TransportOptions
+		// just to enable Wireshark TLS decryption. The empty TransportOptions{} we
+		// pass below has zero-valued fields that all happen to match the "no
+		// transportOptions" defaults (see roundtripper.go), so the only behavioural
+		// difference is the attached KeyLogWriter.
+		options = append(options, tls_client.WithTransportOptions(&tls_client.TransportOptions{
+			KeyLogWriter: w,
+		}))
 	}
 
 	if requestInput.LocalAddress != nil {

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -291,6 +291,35 @@ func BuildResponse(sessionId string, withSession bool, resp *http.Response, cook
 	return response, nil
 }
 
+// ResolveTimeoutOption picks the right tls_client timeout option based on the
+// cffi RequestInput timeout fields. The mapping is:
+//
+//   - timeoutMilliseconds > 0 → WithTimeoutMilliseconds (millisecond precision wins
+//     when both are positive, matching the previous precedence)
+//   - timeoutSeconds      > 0 → WithTimeoutSeconds
+//   - either field        < 0 → WithTimeoutSeconds(0), which the underlying library
+//     interprets as "no deadline" — required for SSE / long-polling streams
+//   - both fields         = 0 → WithTimeoutSeconds(DefaultTimeoutSeconds)
+//
+// The negative sentinel exists because the cffi RequestInput fields are non-pointer
+// ints: 0 cannot be distinguished from "field omitted from JSON", so it has to keep
+// meaning "default" for backwards compatibility. Callers that need a genuinely
+// disabled deadline (e.g. consuming an open-ended event stream) must pass a
+// negative value explicitly.
+func ResolveTimeoutOption(timeoutSeconds, timeoutMilliseconds int) tls_client.HttpClientOption {
+	if timeoutSeconds < 0 || timeoutMilliseconds < 0 {
+		// 0 in the underlying library means "unlimited" — see WithTimeoutSeconds doc.
+		return tls_client.WithTimeoutSeconds(0)
+	}
+	if timeoutMilliseconds > 0 {
+		return tls_client.WithTimeoutMilliseconds(timeoutMilliseconds)
+	}
+	if timeoutSeconds > 0 {
+		return tls_client.WithTimeoutSeconds(timeoutSeconds)
+	}
+	return tls_client.WithTimeoutSeconds(tls_client.DefaultTimeoutSeconds)
+}
+
 func getTlsClient(requestInput RequestInput, sessionId string, withSession bool) (tls_client.HttpClient, error) {
 	clientsLock.Lock()
 	defer clientsLock.Unlock()
@@ -328,18 +357,8 @@ func getTlsClient(requestInput RequestInput, sessionId string, withSession bool)
 		clientProfile = getTlsClientProfile(tlsClientIdentifier)
 	}
 
-	timeoutOption := tls_client.WithTimeoutSeconds(tls_client.DefaultTimeoutSeconds)
-
-	if requestInput.TimeoutSeconds != 0 {
-		timeoutOption = tls_client.WithTimeoutSeconds(requestInput.TimeoutSeconds)
-	}
-
-	if requestInput.TimeoutMilliseconds != 0 {
-		timeoutOption = tls_client.WithTimeoutMilliseconds(requestInput.TimeoutMilliseconds)
-	}
-
 	options := []tls_client.HttpClientOption{
-		timeoutOption,
+		ResolveTimeoutOption(requestInput.TimeoutSeconds, requestInput.TimeoutMilliseconds),
 		tls_client.WithClientProfile(clientProfile),
 	}
 

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -230,10 +230,16 @@ func BuildResponse(sessionId string, withSession bool, resp *http.Response, cook
 			respBodyBytes = nil
 		} else {
 			bodyReader = io.MultiReader(bytes.NewReader(firstByte[:n]), resp.Body)
-			// Automatically detect the charset for non-byte responses
-			bodyReader, err = charset.NewReader(bodyReader, ct)
-			if err != nil {
-				return Response{}, NewTLSClientError(err)
+			// Charset detection is only relevant when the body becomes a string
+			// in the JSON envelope. The stream-to-file path saves raw bytes,
+			// so running them through charset.NewReader would corrupt binary
+			// content — e.g. an image whose body is mostly high-byte values
+			// gets re-encoded windows-1252 → UTF-8 and grows by ~1.6×.
+			if input.StreamOutputPath == nil {
+				bodyReader, err = charset.NewReader(bodyReader, ct)
+				if err != nil {
+					return Response{}, NewTLSClientError(err)
+				}
 			}
 
 			if input.StreamOutputPath != nil {

--- a/cffi_src/factory_with_debug_test.go
+++ b/cffi_src/factory_with_debug_test.go
@@ -1,0 +1,159 @@
+package tls_client_cffi_src
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin down getTlsClient's WithDebug handling. The fix has two
+// observable consequences that we cover here:
+//
+//  1. Logger visibility: when requestInput.WithDebug is true, the constructed
+//     tls_client.HttpClient must emit log output (the cffi caller wanted
+//     diagnostic output — being silent defeats the flag).
+//  2. Cache bypass: when WithDebug=true, getTlsClient must build a fresh
+//     client even if a non-debug client was previously cached against the
+//     same sessionId. Otherwise the cached noop-logger client silently wins
+//     and the flag has no effect.
+//
+// The test exercises both via the unexported getTlsClient. We trigger a
+// well-known logger.Debug call by invoking client.GetCookies(u), which
+// always emits "get cookies for url: ..." through c.logger.Debug, and we
+// capture stdout to verify presence/absence.
+
+// captureStdout swaps os.Stdout for an OS pipe, runs fn, restores stdout,
+// and returns everything fn wrote to stdout. Multiple fmt.Printf calls
+// inside fn are captured in order. The pipe is fully drained on a separate
+// goroutine so a chatty fn can't deadlock by filling the pipe buffer.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err, "os.Pipe")
+
+	origStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() { os.Stdout = origStdout })
+
+	var (
+		mu      sync.Mutex
+		readBuf strings.Builder
+	)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := r.Read(buf)
+			if n > 0 {
+				mu.Lock()
+				readBuf.Write(buf[:n])
+				mu.Unlock()
+			}
+			if readErr != nil {
+				return
+			}
+		}
+	}()
+
+	fn()
+
+	// Closing the writer ends the reader goroutine.
+	_ = w.Close()
+	<-done
+	_ = r.Close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	return readBuf.String()
+}
+
+func cookiesUrl(t *testing.T) *url.URL {
+	t.Helper()
+	u, err := url.Parse("https://example.test/with-debug-test")
+	require.NoError(t, err)
+	return u
+}
+
+// triggerLoggerCall hits a code path that calls c.logger.Debug — namely
+// HttpClient.GetCookies, which logs "get cookies for url: %s". The actual
+// returned cookies don't matter; we only care that the logger fired.
+func triggerLoggerCall(t *testing.T, withDebug bool, sessionId string) string {
+	t.Helper()
+
+	input := RequestInput{
+		TLSClientIdentifier: "chrome_124",
+		WithDebug:           withDebug,
+		FollowRedirects:     true,
+		// Disable the cookie jar so we don't pull in network-style setup;
+		// GetCookies still runs through c.logger.Debug.
+		WithoutCookieJar: true,
+	}
+
+	withSession := sessionId != ""
+	return captureStdout(t, func() {
+		client, err := getTlsClient(input, sessionId, withSession)
+		require.NoError(t, err, "getTlsClient")
+		require.NotNil(t, client, "client must not be nil")
+
+		// Drives c.logger.Debug("get cookies for url: ...")
+		client.GetCookies(cookiesUrl(t))
+	})
+}
+
+func TestGetTlsClient_WithDebugFalse_IsSilent(t *testing.T) {
+	ClearSessionCache()
+
+	out := triggerLoggerCall(t, false, "")
+	assert.Empty(t, strings.TrimSpace(out), "WithDebug=false must not print to stdout; got %q", out)
+}
+
+func TestGetTlsClient_WithDebugTrue_EmitsDebugOutput(t *testing.T) {
+	ClearSessionCache()
+
+	out := triggerLoggerCall(t, true, "")
+	// The exact message is fragile to upstream wording; assert on a stable
+	// substring that uniquely identifies the GetCookies debug log.
+	assert.Contains(t, out, "get cookies for url",
+		"WithDebug=true must surface c.logger.Debug output; got %q", out)
+}
+
+func TestGetTlsClient_WithDebugTrue_AlsoEmitsWarnOutput(t *testing.T) {
+	// The fix's primary intent: not just Debug-level, but Info / Warn /
+	// Error must also reach stdout. With a noop inner logger (the previous
+	// behaviour) the wrapper's Warn forwarded into a no-op and dropped.
+	// GetCookies on a no-jar client emits "you did not setup a cookie jar"
+	// at Warn level — perfect probe.
+	ClearSessionCache()
+
+	out := triggerLoggerCall(t, true, "")
+	assert.Contains(t, out, "you did not setup a cookie jar",
+		"WithDebug=true must surface c.logger.Warn output (not just Debug); got %q", out)
+}
+
+func TestGetTlsClient_WithDebug_BypassesNoopCache(t *testing.T) {
+	// Regression: without the cache bypass, a sessionId first registered
+	// with WithDebug=false would cache its noop client. A later call with
+	// WithDebug=true on the same sessionId would silently retrieve the
+	// cached noop client and emit nothing — the flag would be unobservable.
+	ClearSessionCache()
+
+	const sessionId = "bypass-test"
+
+	// 1) Prime the cache with a non-debug client.
+	silent := triggerLoggerCall(t, false, sessionId)
+	require.Empty(t, strings.TrimSpace(silent), "non-debug priming call should be silent; got %q", silent)
+
+	// 2) Re-enter with WithDebug=true on the SAME sessionId. Without the
+	// cache bypass this would reuse the noop client and stay silent.
+	loud := triggerLoggerCall(t, true, sessionId)
+	assert.Contains(t, loud, "get cookies for url",
+		"WithDebug=true on a previously-cached session must rebuild the client and emit debug output; got %q", loud)
+}
+

--- a/cffi_src/stream.go
+++ b/cffi_src/stream.go
@@ -1,0 +1,407 @@
+package tls_client_cffi_src
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+
+	http "github.com/bogdanfinn/fhttp"
+	"github.com/google/uuid"
+	"golang.org/x/net/html/charset"
+)
+
+// backpressureTimeout bounds how long the pump goroutine will block trying to
+// hand off a chunk before giving up. It exists so a misbehaving caller (one
+// that stops reading without calling cancelStream) cannot keep the underlying
+// connection and goroutine alive indefinitely.
+const backpressureTimeout = 60 * time.Second
+
+// defaultStreamBlockSize is the per-Read buffer size when StreamOutputBlockSize
+// is not specified on the RequestInput.
+const defaultStreamBlockSize = 4096
+
+// streamChannelCapacity is the buffered capacity of the chunk channel between
+// the pump goroutine and the readStream caller. Higher values smooth out short
+// caller stalls; lower values keep memory bounded.
+const streamChannelCapacity = 64
+
+// StreamChunk is one item produced by the pump goroutine and consumed by
+// readStream / readStreamAll. Exactly one of Data, EOF, or Err is meaningful.
+type StreamChunk struct {
+	Err  error
+	Data []byte
+	EOF  bool
+}
+
+// StreamState tracks one in-flight streaming response.
+//
+// Headers/status/cookies are captured at start time so readStreamAll can
+// produce a complete Response envelope without the caller having to merge
+// the requestStream envelope back in.
+type StreamState struct {
+	cancel      context.CancelFunc
+	body        io.ReadCloser
+	Chunks      chan StreamChunk
+	Headers     http.Header
+	Cookies     []*http.Cookie
+	SessionId   string
+	Proto       string
+	Target      string
+	ContentType string
+	Status      int
+	WithSession bool
+
+	// IsByteResponse mirrors the original RequestInput so readStreamAll
+	// formats the body the same way the non-streaming path would have.
+	IsByteResponse bool
+
+	closeOnce sync.Once
+}
+
+// StartStreamParams bundles the inputs needed to register a streaming
+// response. The caller is responsible for having already issued the request
+// and obtained the response headers.
+type StartStreamParams struct {
+	Response       *http.Response
+	Cookies        []*http.Cookie
+	Cancel         context.CancelFunc
+	SessionId      string
+	WithSession    bool
+	IsByteResponse bool
+	BlockSize      int // <= 0 falls back to defaultStreamBlockSize
+}
+
+// StartStream wraps the response body with decompression (when applicable),
+// constructs a StreamState, registers it under streamId, and spawns the pump
+// goroutine. It returns the registered StreamState so the caller can build
+// the requestStream envelope.
+func StartStream(streamId string, p StartStreamParams) *StreamState {
+	resp := p.Response
+
+	body := resp.Body
+	if !resp.Uncompressed {
+		body = http.DecompressBodyByType(body, resp.Header.Get("Content-Encoding"))
+	}
+
+	target := ""
+	if resp.Request != nil && resp.Request.URL != nil {
+		target = resp.Request.URL.String()
+	}
+
+	state := &StreamState{
+		cancel:         p.Cancel,
+		body:           body,
+		Chunks:         make(chan StreamChunk, streamChannelCapacity),
+		Headers:        resp.Header,
+		Cookies:        p.Cookies,
+		SessionId:      p.SessionId,
+		Proto:          resp.Proto,
+		Target:         target,
+		ContentType:    resp.Header.Get("Content-Type"),
+		Status:         resp.StatusCode,
+		WithSession:    p.WithSession,
+		IsByteResponse: p.IsByteResponse,
+	}
+
+	RegisterStream(streamId, state)
+	go pumpStream(state, p.BlockSize)
+	return state
+}
+
+// Close is idempotent. It cancels the request context (which closes the
+// underlying TCP/TLS connection and unblocks any in-flight body Read).
+func (s *StreamState) Close() {
+	s.closeOnce.Do(func() {
+		if s.cancel != nil {
+			s.cancel()
+		}
+	})
+}
+
+var (
+	streamsLock sync.Mutex
+	streams     = make(map[string]*StreamState)
+)
+
+// RegisterStream stores a freshly created StreamState under streamId. The
+// caller takes responsibility for spawning the pump goroutine.
+func RegisterStream(streamId string, state *StreamState) {
+	streamsLock.Lock()
+	defer streamsLock.Unlock()
+	streams[streamId] = state
+}
+
+// GetStream returns the StreamState for streamId, or (nil, false) if none.
+func GetStream(streamId string) (*StreamState, bool) {
+	streamsLock.Lock()
+	defer streamsLock.Unlock()
+	s, ok := streams[streamId]
+	return s, ok
+}
+
+// removeStream deletes the registry entry for streamId and returns the
+// previously stored StreamState. Callers should also invoke Close on the
+// returned state to release the underlying connection.
+func removeStream(streamId string) (*StreamState, bool) {
+	streamsLock.Lock()
+	defer streamsLock.Unlock()
+	s, ok := streams[streamId]
+	if ok {
+		delete(streams, streamId)
+	}
+	return s, ok
+}
+
+// ClearStreamCache cancels and removes every registered stream. It is safe to
+// call from destroyAll.
+func ClearStreamCache() {
+	streamsLock.Lock()
+	toClose := make([]*StreamState, 0, len(streams))
+	for _, s := range streams {
+		toClose = append(toClose, s)
+	}
+	streams = make(map[string]*StreamState)
+	streamsLock.Unlock()
+
+	for _, s := range toClose {
+		s.Close()
+	}
+}
+
+// pumpStream reads from state.body in blockSize chunks and pushes them onto
+// state.Chunks. It terminates on EOF, on read error, or when the consumer
+// stalls for longer than backpressureTimeout. The chunk channel is closed
+// before the goroutine returns.
+func pumpStream(state *StreamState, blockSize int) {
+	defer func() {
+		_ = state.body.Close()
+		close(state.Chunks)
+	}()
+
+	if blockSize <= 0 {
+		blockSize = defaultStreamBlockSize
+	}
+
+	for {
+		buf := make([]byte, blockSize)
+		n, readErr := state.body.Read(buf)
+
+		if n > 0 {
+			if !sendChunk(state.Chunks, StreamChunk{Data: buf[:n]}) {
+				return
+			}
+		}
+
+		if readErr == io.EOF {
+			sendChunk(state.Chunks, StreamChunk{EOF: true})
+			return
+		}
+		if readErr != nil {
+			sendChunk(state.Chunks, StreamChunk{Err: readErr})
+			return
+		}
+	}
+}
+
+func sendChunk(ch chan<- StreamChunk, chunk StreamChunk) bool {
+	select {
+	case ch <- chunk:
+		return true
+	case <-time.After(backpressureTimeout):
+		return false
+	}
+}
+
+// BuildStreamStartResponse constructs the envelope returned by requestStream.
+// The caller is expected to register the StreamState and spawn the pump after
+// this returns.
+func BuildStreamStartResponse(streamId string, state *StreamState) StreamStartResponse {
+	response := Response{
+		Id:           uuid.New().String(),
+		Status:       state.Status,
+		UsedProtocol: state.Proto,
+		Body:         "",
+		Headers:      state.Headers,
+		Target:       state.Target,
+		Cookies:      cookiesToMap(state.Cookies),
+	}
+
+	if state.WithSession {
+		response.SessionId = state.SessionId
+	}
+
+	return StreamStartResponse{
+		Response: response,
+		StreamId: streamId,
+	}
+}
+
+// ReadStreamChunk pulls the next chunk from the registry, applying timeoutMs
+// semantics as documented on ReadStreamInput. On EOF or error it removes the
+// stream from the registry and closes its underlying connection.
+func ReadStreamChunk(streamId string, timeoutMs int) StreamChunkResponse {
+	state, ok := GetStream(streamId)
+	if !ok {
+		return StreamChunkResponse{
+			Id:       uuid.New().String(),
+			StreamId: streamId,
+			Error:    fmt.Sprintf("unknown streamId: %s", streamId),
+		}
+	}
+
+	switch {
+	case timeoutMs < 0:
+		chunk, open := <-state.Chunks
+		return finalizeChunk(streamId, state, chunk, open)
+	case timeoutMs == 0:
+		select {
+		case chunk, open := <-state.Chunks:
+			return finalizeChunk(streamId, state, chunk, open)
+		default:
+			return StreamChunkResponse{
+				Id:       uuid.New().String(),
+				StreamId: streamId,
+				Timeout:  true,
+			}
+		}
+	default:
+		select {
+		case chunk, open := <-state.Chunks:
+			return finalizeChunk(streamId, state, chunk, open)
+		case <-time.After(time.Duration(timeoutMs) * time.Millisecond):
+			return StreamChunkResponse{
+				Id:       uuid.New().String(),
+				StreamId: streamId,
+				Timeout:  true,
+			}
+		}
+	}
+}
+
+func finalizeChunk(streamId string, state *StreamState, chunk StreamChunk, open bool) StreamChunkResponse {
+	if !open {
+		// Channel was closed without a final EOF/Err — pump exited via
+		// backpressure timeout. Treat as a non-fatal EOF for the caller.
+		_, _ = removeStream(streamId)
+		state.Close()
+		return StreamChunkResponse{
+			Id:       uuid.New().String(),
+			StreamId: streamId,
+			EOF:      true,
+		}
+	}
+
+	if chunk.Err != nil {
+		_, _ = removeStream(streamId)
+		state.Close()
+		return StreamChunkResponse{
+			Id:       uuid.New().String(),
+			StreamId: streamId,
+			Error:    chunk.Err.Error(),
+		}
+	}
+
+	if chunk.EOF {
+		_, _ = removeStream(streamId)
+		state.Close()
+		return StreamChunkResponse{
+			Id:       uuid.New().String(),
+			StreamId: streamId,
+			EOF:      true,
+		}
+	}
+
+	return StreamChunkResponse{
+		Id:       uuid.New().String(),
+		StreamId: streamId,
+		Chunk:    base64.StdEncoding.EncodeToString(chunk.Data),
+	}
+}
+
+// ReadStreamAll drains the rest of the body in one shot and returns a full
+// Response envelope, formatted the same way BuildResponse would have for a
+// non-streaming request (charset decoding for text bodies, base64 + MIME
+// prefix for byte responses). After this returns, streamId is invalid.
+func ReadStreamAll(streamId string) (Response, *TLSClientError) {
+	state, ok := GetStream(streamId)
+	if !ok {
+		return Response{}, NewTLSClientError(fmt.Errorf("unknown streamId: %s", streamId))
+	}
+
+	var buf bytes.Buffer
+	var streamErr error
+
+	for chunk := range state.Chunks {
+		if chunk.Err != nil {
+			streamErr = chunk.Err
+			break
+		}
+		if len(chunk.Data) > 0 {
+			buf.Write(chunk.Data)
+		}
+		if chunk.EOF {
+			break
+		}
+	}
+
+	_, _ = removeStream(streamId)
+	state.Close()
+
+	if streamErr != nil {
+		return Response{}, NewTLSClientError(streamErr)
+	}
+
+	bodyBytes := buf.Bytes()
+	finalBody := ""
+
+	if state.IsByteResponse {
+		mimeType := http.DetectContentType(bodyBytes)
+		finalBody = fmt.Sprintf("data:%s;base64,", mimeType) + base64.StdEncoding.EncodeToString(bodyBytes)
+	} else if len(bodyBytes) > 0 {
+		// Mirror the charset detection BuildResponse does for non-byte bodies.
+		reader, err := charset.NewReader(bytes.NewReader(bodyBytes), state.ContentType)
+		if err != nil {
+			return Response{}, NewTLSClientError(err)
+		}
+		decoded, err := io.ReadAll(reader)
+		if err != nil {
+			return Response{}, NewTLSClientError(err)
+		}
+		finalBody = string(decoded)
+	}
+
+	response := Response{
+		Id:           uuid.New().String(),
+		Status:       state.Status,
+		UsedProtocol: state.Proto,
+		Body:         finalBody,
+		Headers:      state.Headers,
+		Target:       state.Target,
+		Cookies:      cookiesToMap(state.Cookies),
+	}
+	if state.WithSession {
+		response.SessionId = state.SessionId
+	}
+	return response, nil
+}
+
+// CancelStream tears down the stream identified by streamId. It is idempotent:
+// calling it after a natural EOF, after an error, or with an unknown streamId
+// returns success without doing any work.
+func CancelStream(streamId string) {
+	state, ok := removeStream(streamId)
+	if !ok {
+		return
+	}
+	state.Close()
+	// Drain any remaining chunks so the pump goroutine, which is blocked on
+	// sendChunk, can terminate promptly.
+	go func() {
+		for range state.Chunks {
+		}
+	}()
+}

--- a/cffi_src/types.go
+++ b/cffi_src/types.go
@@ -204,3 +204,54 @@ type Response struct {
 	UsedProtocol string              `json:"usedProtocol"`
 	Status       int                 `json:"status"`
 }
+
+// ReadStreamInput is the input for the readStream cffi export.
+//
+// TimeoutMs:
+//
+//	< 0  block until the next chunk, EOF, or error
+//	  0  non-blocking poll: returns Timeout=true immediately when no chunk is buffered
+//	> 0  block up to TimeoutMs, then return Timeout=true if no chunk arrived
+type ReadStreamInput struct {
+	StreamId  string `json:"streamId"`
+	TimeoutMs int    `json:"timeoutMs"`
+}
+
+// ReadStreamAllInput is the input for the readStreamAll cffi export.
+type ReadStreamAllInput struct {
+	StreamId string `json:"streamId"`
+}
+
+// CancelStreamInput is the input for the cancelStream cffi export.
+type CancelStreamInput struct {
+	StreamId string `json:"streamId"`
+}
+
+// StreamStartResponse is returned by requestStream. It carries the same fields
+// as Response (status, headers, cookies, ...) with an empty Body and an
+// additional StreamId. The caller uses StreamId for subsequent readStream /
+// readStreamAll / cancelStream calls. Body is always empty here.
+type StreamStartResponse struct {
+	Response
+	StreamId string `json:"streamId"`
+}
+
+// StreamChunkResponse is returned by readStream.
+//
+// Exactly one of EOF, Timeout, Error, or a non-empty Chunk is set on a
+// successful call:
+//   - Chunk (base64) holds the next slice of decompressed body bytes.
+//   - EOF=true means the stream completed naturally; the StreamId is invalid
+//     after this call.
+//   - Timeout=true means no data was available within TimeoutMs; the stream
+//     is still live and the caller may retry.
+//   - Error holds a non-empty message when the underlying read failed; the
+//     StreamId is invalid after this call.
+type StreamChunkResponse struct {
+	Id       string `json:"id"`
+	StreamId string `json:"streamId"`
+	Chunk    string `json:"chunk"`
+	Error    string `json:"error,omitempty"`
+	EOF      bool   `json:"eof"`
+	Timeout  bool   `json:"timeout"`
+}

--- a/cffi_src/types.go
+++ b/cffi_src/types.go
@@ -48,6 +48,11 @@ type CookiesFromSessionOutput struct {
 }
 
 // RequestInput is the data a Python client can construct a client and request from.
+//
+// TimeoutSeconds / TimeoutMilliseconds: 0 means "use the default timeout" (30s),
+// a positive value sets an explicit deadline, and a negative value disables the
+// deadline entirely (required for long-lived SSE / streaming responses). See
+// ResolveTimeoutOption for the precedence rules between the two fields.
 type RequestInput struct {
 	CertificatePinningHosts     map[string][]string `json:"certificatePinningHosts"`
 	CustomTlsClient             *CustomTlsClient    `json:"customTlsClient"`

--- a/tests/byte_response_test.go
+++ b/tests/byte_response_test.go
@@ -1,0 +1,147 @@
+package tests
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"io"
+	"strings"
+	"testing"
+
+	tls_client_cffi_src "github.com/bogdanfinn/tls-client/cffi_src"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin down BuildResponse's byte-response branch. Regression
+// motivation: a refactor previously moved io.ReadAll inside the !isByteResponse
+// arm only, so every IsByteResponse=true request silently returned an empty
+// payload (just the "data:<mime>;base64," prefix with no body). The branches
+// below cover the read-decode-encode path that the bug bypassed.
+
+// buildByteResponseInput returns a minimal RequestInput with IsByteResponse=true.
+// All other knobs are left at zero values — BuildResponse only reads
+// IsByteResponse and StreamOutputPath off RequestInput.
+func buildByteResponseInput() tls_client_cffi_src.RequestInput {
+	return tls_client_cffi_src.RequestInput{
+		IsByteResponse: true,
+	}
+}
+
+// decodeDataURL splits a "data:<mime>;base64,<payload>" body into mime + raw
+// bytes. Fails the test if the envelope is malformed.
+func decodeDataURL(t *testing.T, body string) (mime string, payload []byte) {
+	t.Helper()
+	require.True(t, strings.HasPrefix(body, "data:"), "byte response body must start with data: prefix; got %q", body)
+	prefix, encoded, found := strings.Cut(body, ";base64,")
+	require.True(t, found, "byte response body must contain ;base64, separator; got %q", body)
+	mime = strings.TrimPrefix(prefix, "data:")
+	got, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err, "base64 decode of body payload")
+	return mime, got
+}
+
+func TestBuildResponse_ByteResponse_BinaryPayloadReturnedAsBase64DataUrl(t *testing.T) {
+	// Bytes that don't survive a UTF-8 round trip — proves we're not silently
+	// running through the charset/text path.
+	payload := []byte{0x00, 0x01, 0xFF, 0xFE, 0x80, 0x7F, 0x42, 0x00, 0xC3, 0x28}
+
+	resp := streamMakeResp(io.NopCloser(bytes.NewReader(payload)), "application/octet-stream", "", true)
+
+	out, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, buildByteResponseInput())
+	require.Nil(t, err, "BuildResponse returned error: %v", err)
+
+	assert.Equal(t, 200, out.Status)
+	mime, decoded := decodeDataURL(t, out.Body)
+	assert.NotEmpty(t, mime, "mime type should be detected and present in data URL")
+	assert.Equal(t, payload, decoded, "decoded payload must match the original bytes")
+}
+
+func TestBuildResponse_ByteResponse_EmptyBody(t *testing.T) {
+	// Empty bodies must still produce a well-formed envelope: the bug regressed
+	// every byte response into looking like an empty body, which made this
+	// case indistinguishable from "real content lost". Pin the contract:
+	// empty input → valid data URL with zero-length payload.
+	resp := streamMakeResp(io.NopCloser(strings.NewReader("")), "application/octet-stream", "", true)
+
+	out, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, buildByteResponseInput())
+	require.Nil(t, err, "BuildResponse returned error: %v", err)
+
+	mime, decoded := decodeDataURL(t, out.Body)
+	assert.NotEmpty(t, mime, "mime type should still be set even for empty body")
+	assert.Empty(t, decoded, "decoded payload should be empty for an empty body")
+}
+
+func TestBuildResponse_ByteResponse_LargerPayloadFullyRead(t *testing.T) {
+	// Larger-than-default-buffer payload with non-text bytes. Catches a
+	// regression where a partial-read bug would truncate the body without
+	// surfacing an error.
+	const size = 64 * 1024
+	payload := make([]byte, size)
+	for i := range payload {
+		payload[i] = byte(i % 256)
+	}
+
+	resp := streamMakeResp(io.NopCloser(bytes.NewReader(payload)), "application/octet-stream", "", true)
+
+	out, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, buildByteResponseInput())
+	require.Nil(t, err, "BuildResponse returned error: %v", err)
+
+	_, decoded := decodeDataURL(t, out.Body)
+	assert.Equal(t, len(payload), len(decoded), "decoded length mismatch")
+	assert.Equal(t, payload, decoded, "decoded payload must match input byte-for-byte")
+}
+
+func TestBuildResponse_ByteResponse_GzipDecompression(t *testing.T) {
+	// Byte responses still flow through DecompressBodyByType — verify gzip is
+	// transparently expanded before base64 encoding the *decompressed* bytes.
+	original := []byte{0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, err := gz.Write(original)
+	require.NoError(t, err, "gzip write")
+	require.NoError(t, gz.Close(), "gzip close")
+
+	// uncompressed=false signals BuildResponse to apply DecompressBodyByType.
+	resp := streamMakeResp(io.NopCloser(bytes.NewReader(compressed.Bytes())), "application/octet-stream", "gzip", false)
+
+	out, buildErr := tls_client_cffi_src.BuildResponse("", false, resp, nil, buildByteResponseInput())
+	require.Nil(t, buildErr, "BuildResponse returned error: %v", buildErr)
+
+	_, decoded := decodeDataURL(t, out.Body)
+	assert.Equal(t, original, decoded, "byte response body must be the gzip-decompressed bytes, not the gzipped bytes")
+}
+
+func TestBuildResponse_TextResponseStillReadsFullBody(t *testing.T) {
+	// Sanity check on the !isByteResponse branch — make sure the byte-branch
+	// fix didn't accidentally regress the original text path.
+	const payload = `{"hello":"world"}`
+	resp := streamMakeResp(io.NopCloser(strings.NewReader(payload)), "application/json; charset=utf-8", "", true)
+
+	input := tls_client_cffi_src.RequestInput{IsByteResponse: false}
+
+	out, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, input)
+	require.Nil(t, err, "BuildResponse returned error: %v", err)
+
+	assert.Equal(t, payload, out.Body)
+	assert.Equal(t, 200, out.Status)
+}
+
+func TestBuildResponse_ByteResponse_PreservesHeadersAndSession(t *testing.T) {
+	// Headers and session metadata shouldn't be lost on the byte path either.
+	payload := []byte{0x01, 0x02, 0x03}
+	resp := streamMakeResp(io.NopCloser(bytes.NewReader(payload)), "application/pdf", "", true)
+	resp.Header.Set("X-Custom", "kept")
+
+	out, err := tls_client_cffi_src.BuildResponse("session-x", true, resp, nil, buildByteResponseInput())
+	require.Nil(t, err)
+
+	assert.Equal(t, []string{"kept"}, out.Headers["X-Custom"], "custom header should survive the byte path")
+	assert.Equal(t, "session-x", out.SessionId, "session id should be propagated when withSession=true")
+	assert.NotEmpty(t, out.Target, "target should reflect the request URL")
+	assert.NotEmpty(t, out.Id, "response should have an id (used for freeMemory tracking)")
+
+	_, decoded := decodeDataURL(t, out.Body)
+	assert.Equal(t, payload, decoded)
+}

--- a/tests/stream_test.go
+++ b/tests/stream_test.go
@@ -1,0 +1,566 @@
+package tests
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	http "github.com/bogdanfinn/fhttp"
+	"github.com/bogdanfinn/fhttp/httptest"
+	tls_client "github.com/bogdanfinn/tls-client"
+	tls_client_cffi_src "github.com/bogdanfinn/tls-client/cffi_src"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// -----------------------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------------------
+
+// streamMakeResp builds a minimal *http.Response usable as input to StartStream.
+//
+// uncompressed=true tells the stream to skip DecompressBodyByType (i.e. the
+// body is already plaintext); set it to false together with a Content-Encoding
+// header to exercise gzip decompression.
+func streamMakeResp(body io.ReadCloser, contentType, contentEncoding string, uncompressed bool) *http.Response {
+	h := http.Header{}
+	if contentType != "" {
+		h.Set("Content-Type", contentType)
+	}
+	if contentEncoding != "" {
+		h.Set("Content-Encoding", contentEncoding)
+	}
+	u, _ := url.Parse("https://example.test/streaming")
+	return &http.Response{
+		Body:         body,
+		Header:       h,
+		StatusCode:   200,
+		Proto:        "HTTP/1.1",
+		Request:      &http.Request{URL: u},
+		Uncompressed: uncompressed,
+	}
+}
+
+// streamStart mints a fresh stream id, registers a cleanup that cancels it,
+// and returns the id + state.
+func streamStart(t *testing.T, params tls_client_cffi_src.StartStreamParams) (string, *tls_client_cffi_src.StreamState) {
+	t.Helper()
+	streamId := fmt.Sprintf("stream-%s", t.Name())
+	state := tls_client_cffi_src.StartStream(streamId, params)
+	t.Cleanup(func() { tls_client_cffi_src.CancelStream(streamId) })
+	return streamId, state
+}
+
+func streamDecodeChunk(t *testing.T, out tls_client_cffi_src.StreamChunkResponse) []byte {
+	t.Helper()
+	if out.Chunk == "" {
+		return nil
+	}
+	b, err := base64.StdEncoding.DecodeString(out.Chunk)
+	require.NoError(t, err, "base64 decode of chunk")
+	return b
+}
+
+// streamDrain reads chunks until EOF or error, concatenating their bytes. It
+// returns the assembled bytes and the final terminating chunk response.
+func streamDrain(t *testing.T, streamId string) ([]byte, tls_client_cffi_src.StreamChunkResponse) {
+	t.Helper()
+	var buf bytes.Buffer
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		require.False(t, time.Now().After(deadline), "drain deadline exceeded; pump appears stuck")
+		out := tls_client_cffi_src.ReadStreamChunk(streamId, 1000)
+		if out.Error != "" {
+			return buf.Bytes(), out
+		}
+		if out.Timeout {
+			continue
+		}
+		buf.Write(streamDecodeChunk(t, out))
+		if out.EOF {
+			return buf.Bytes(), out
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// ReadStreamChunk
+// -----------------------------------------------------------------------------
+
+func TestStream_DrainsBodyThenEOF(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	body := io.NopCloser(strings.NewReader("hello world"))
+	resp := streamMakeResp(body, "text/plain; charset=utf-8", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() {},
+		BlockSize: 1024,
+	})
+
+	got, terminal := streamDrain(t, streamId)
+	assert.True(t, terminal.EOF, "expected EOF terminal chunk")
+	assert.Equal(t, "hello world", string(got))
+
+	// Subsequent reads on a finished stream surface as Error: unknown streamId.
+	out := tls_client_cffi_src.ReadStreamChunk(streamId, 100)
+	assert.NotEmpty(t, out.Error, "expected unknown-streamId error after EOF")
+
+	_, ok := tls_client_cffi_src.GetStream(streamId)
+	assert.False(t, ok, "stream still in registry after EOF")
+}
+
+func TestStream_ChunksByBlockSize(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	const blockSize = 16
+	const total = 100
+	payload := bytes.Repeat([]byte{'x'}, total)
+	body := io.NopCloser(bytes.NewReader(payload))
+	resp := streamMakeResp(body, "application/octet-stream", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() {},
+		BlockSize: blockSize,
+	})
+
+	got, terminal := streamDrain(t, streamId)
+	assert.True(t, terminal.EOF, "expected EOF")
+	assert.Equal(t, payload, got)
+}
+
+func TestStream_UnknownStreamId(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	out := tls_client_cffi_src.ReadStreamChunk("does-not-exist", 100)
+	assert.NotEmpty(t, out.Error, "expected error for unknown streamId")
+	assert.Contains(t, out.Error, "unknown streamId")
+}
+
+func TestStream_NonBlockingPollNoData(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	pr, _ := io.Pipe()
+	resp := streamMakeResp(io.NopCloser(pr), "text/event-stream", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() { _ = pr.Close() },
+		BlockSize: 64,
+	})
+
+	// Pump is blocked on pipe.Read; channel is empty.
+	out := tls_client_cffi_src.ReadStreamChunk(streamId, 0)
+	assert.True(t, out.Timeout, "expected Timeout=true on non-blocking poll with no data")
+	assert.Empty(t, out.Chunk)
+	assert.False(t, out.EOF)
+	assert.Empty(t, out.Error)
+}
+
+func TestStream_TimeoutThenData(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	pr, pw := io.Pipe()
+	resp := streamMakeResp(io.NopCloser(pr), "text/event-stream", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() { _ = pr.Close() },
+		BlockSize: 64,
+	})
+
+	// Initial read with no data → Timeout.
+	out := tls_client_cffi_src.ReadStreamChunk(streamId, 100)
+	assert.True(t, out.Timeout, "expected Timeout=true")
+
+	// Now produce some data.
+	go func() { _, _ = pw.Write([]byte("data: ping\n\n")) }()
+
+	out = tls_client_cffi_src.ReadStreamChunk(streamId, 1000)
+	require.Empty(t, out.Error, "read error")
+	assert.False(t, out.Timeout, "expected data, got Timeout")
+	assert.Equal(t, "data: ping\n\n", string(streamDecodeChunk(t, out)))
+}
+
+func TestStream_BlockingNegativeTimeoutWaitsForData(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	pr, pw := io.Pipe()
+	resp := streamMakeResp(io.NopCloser(pr), "text/event-stream", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() { _ = pr.Close() },
+		BlockSize: 64,
+	})
+
+	const delay = 200 * time.Millisecond
+	const payload = "delayed"
+	go func() {
+		time.Sleep(delay)
+		_, _ = pw.Write([]byte(payload))
+	}()
+
+	start := time.Now()
+	out := tls_client_cffi_src.ReadStreamChunk(streamId, -1) // block
+	elapsed := time.Since(start)
+
+	require.Empty(t, out.Error, "read error")
+	assert.Equal(t, payload, string(streamDecodeChunk(t, out)))
+	assert.GreaterOrEqual(t, elapsed, delay, "ReadStreamChunk(-1) returned too early; did it actually block?")
+}
+
+func TestStream_SurfacesReadError(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	pr, pw := io.Pipe()
+	wantErr := errors.New("synthetic body failure")
+
+	resp := streamMakeResp(io.NopCloser(pr), "text/event-stream", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() { _ = pr.Close() },
+		BlockSize: 64,
+	})
+
+	// Producer writes data then errors.
+	go func() {
+		_, _ = pw.Write([]byte("partial"))
+		_ = pw.CloseWithError(wantErr)
+	}()
+
+	got, terminal := streamDrain(t, streamId)
+	assert.Equal(t, "partial", string(got), "data buffered before error must still be delivered")
+	assert.NotEmpty(t, terminal.Error, "expected error terminator")
+	assert.Contains(t, terminal.Error, wantErr.Error())
+
+	// Stream is removed after error.
+	_, ok := tls_client_cffi_src.GetStream(streamId)
+	assert.False(t, ok, "stream still registered after error")
+}
+
+// -----------------------------------------------------------------------------
+// CancelStream
+// -----------------------------------------------------------------------------
+
+func TestStream_CancelRemovesAndReleases(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	pr, pw := io.Pipe()
+	cancelCalled := make(chan struct{})
+	var cancelOnce sync.Once
+	resp := streamMakeResp(io.NopCloser(pr), "text/event-stream", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response: resp,
+		Cancel: func() {
+			cancelOnce.Do(func() {
+				close(cancelCalled)
+				_ = pr.Close() // simulate ctx cancel propagating to body
+			})
+		},
+		BlockSize: 64,
+	})
+
+	go func() { _, _ = pw.Write([]byte("hello")) }()
+
+	out := tls_client_cffi_src.ReadStreamChunk(streamId, 1000)
+	require.Empty(t, out.Error, "first read failed")
+	assert.Equal(t, "hello", string(streamDecodeChunk(t, out)))
+
+	tls_client_cffi_src.CancelStream(streamId)
+
+	select {
+	case <-cancelCalled:
+	case <-time.After(time.Second):
+		t.Fatal("cancel func was not invoked within 1s")
+	}
+
+	_, ok := tls_client_cffi_src.GetStream(streamId)
+	assert.False(t, ok, "stream still registered after cancel")
+
+	out = tls_client_cffi_src.ReadStreamChunk(streamId, 100)
+	assert.NotEmpty(t, out.Error, "expected error reading cancelled stream")
+}
+
+func TestStream_CancelIsIdempotent(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	// Unknown id: must not panic, must not error (it's intentionally a no-op).
+	tls_client_cffi_src.CancelStream("never-existed")
+
+	// Cancel a real stream twice.
+	body := io.NopCloser(strings.NewReader("data"))
+	resp := streamMakeResp(body, "text/plain", "", true)
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() {},
+		BlockSize: 64,
+	})
+
+	tls_client_cffi_src.CancelStream(streamId)
+	tls_client_cffi_src.CancelStream(streamId) // second call must not panic
+}
+
+// -----------------------------------------------------------------------------
+// ReadStreamAll
+// -----------------------------------------------------------------------------
+
+func TestStream_ReadStreamAllTextBody(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	const payload = `{"hello":"world"}`
+	body := io.NopCloser(strings.NewReader(payload))
+	resp := streamMakeResp(body, "application/json; charset=utf-8", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() {},
+		BlockSize: 64,
+	})
+
+	response, drainErr := tls_client_cffi_src.ReadStreamAll(streamId)
+	require.Nil(t, drainErr, "ReadStreamAll failed")
+
+	assert.Equal(t, payload, response.Body)
+	assert.Equal(t, 200, response.Status)
+	assert.NotEmpty(t, response.Headers["Content-Type"], "Content-Type header should be preserved")
+
+	_, ok := tls_client_cffi_src.GetStream(streamId)
+	assert.False(t, ok, "stream should be removed after ReadStreamAll")
+}
+
+func TestStream_ReadStreamAllByteResponseBase64(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	// Binary content that does NOT survive a UTF-8 charset round-trip, so
+	// the byte path is genuinely exercised.
+	payload := []byte{0xff, 0xfe, 0x00, 0x01, 0x80, 0x00, 0x42}
+	body := io.NopCloser(bytes.NewReader(payload))
+	resp := streamMakeResp(body, "", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:       resp,
+		Cancel:         func() {},
+		BlockSize:      64,
+		IsByteResponse: true,
+	})
+
+	response, drainErr := tls_client_cffi_src.ReadStreamAll(streamId)
+	require.Nil(t, drainErr)
+
+	prefix, encoded, found := strings.Cut(response.Body, ";base64,")
+	require.True(t, found, "byte response body should be a data URL; got %q", response.Body)
+	assert.True(t, strings.HasPrefix(prefix, "data:"))
+
+	got, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err, "base64 decode")
+	assert.Equal(t, payload, got)
+}
+
+func TestStream_ReadStreamAllAfterPartialReads(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	const payload = "abcdefghij" // 10 bytes
+	body := io.NopCloser(strings.NewReader(payload))
+	resp := streamMakeResp(body, "text/plain; charset=utf-8", "", true)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() {},
+		BlockSize: 4, // forces multiple chunks
+	})
+
+	first := tls_client_cffi_src.ReadStreamChunk(streamId, 1000)
+	require.Empty(t, first.Error, "first read failed")
+	firstBytes := streamDecodeChunk(t, first)
+	assert.NotEmpty(t, firstBytes, "first chunk must contain bytes")
+	assert.LessOrEqual(t, len(firstBytes), 4, "first chunk must respect block size")
+
+	rest, err := tls_client_cffi_src.ReadStreamAll(streamId)
+	require.Nil(t, err, "ReadStreamAll failed")
+
+	assert.Equal(t, payload, string(firstBytes)+rest.Body)
+}
+
+// -----------------------------------------------------------------------------
+// gzip decompression
+// -----------------------------------------------------------------------------
+
+func TestStream_DecompressesGzipBodies(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	const original = "the quick brown fox jumps over the lazy dog"
+
+	var compressed bytes.Buffer
+	gz := gzip.NewWriter(&compressed)
+	_, err := gz.Write([]byte(original))
+	require.NoError(t, err, "gzip write")
+	require.NoError(t, gz.Close(), "gzip close")
+
+	body := io.NopCloser(bytes.NewReader(compressed.Bytes()))
+	// uncompressed=false → DecompressBodyByType is applied inside StartStream.
+	resp := streamMakeResp(body, "text/plain; charset=utf-8", "gzip", false)
+
+	streamId, _ := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    func() {},
+		BlockSize: 64,
+	})
+
+	got, terminal := streamDrain(t, streamId)
+	assert.True(t, terminal.EOF, "expected EOF")
+	assert.Equal(t, original, string(got), "body should be transparently decompressed")
+}
+
+// -----------------------------------------------------------------------------
+// BuildStreamStartResponse / ClearStreamCache
+// -----------------------------------------------------------------------------
+
+func TestStream_BuildStreamStartResponseEnvelope(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	body := io.NopCloser(strings.NewReader(""))
+	resp := streamMakeResp(body, "text/event-stream", "", true)
+	resp.Header.Set("X-Custom", "hello")
+	resp.StatusCode = 202
+	resp.Proto = "HTTP/2.0"
+
+	streamId, state := streamStart(t, tls_client_cffi_src.StartStreamParams{
+		Response:    resp,
+		Cancel:      func() {},
+		SessionId:   "sess-42",
+		WithSession: true,
+		BlockSize:   64,
+	})
+
+	out := tls_client_cffi_src.BuildStreamStartResponse(streamId, state)
+
+	assert.Equal(t, streamId, out.StreamId)
+	assert.Equal(t, 202, out.Status)
+	assert.Equal(t, "HTTP/2.0", out.UsedProtocol)
+	assert.Equal(t, "sess-42", out.SessionId)
+	assert.Equal(t, []string{"hello"}, out.Headers["X-Custom"])
+	assert.Empty(t, out.Body, "Body must be empty for stream start envelope")
+	assert.NotEmpty(t, out.Target, "Target should be the request URL")
+	assert.NotEmpty(t, out.Id, "envelope must have an Id (used for freeMemory)")
+}
+
+func TestStream_ClearStreamCacheRemovesAll(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	// Use pipes so the pump goroutines block — i.e. streams stay alive
+	// rather than racing to EOF before ClearStreamCache runs.
+	pipes := make([]*io.PipeWriter, 0, 3)
+	ids := make([]string, 0, 3)
+	for i := 0; i < 3; i++ {
+		pr, pw := io.Pipe()
+		pipes = append(pipes, pw)
+		resp := streamMakeResp(io.NopCloser(pr), "text/event-stream", "", true)
+		streamId := fmt.Sprintf("clear-cache-%d", i)
+		tls_client_cffi_src.StartStream(streamId, tls_client_cffi_src.StartStreamParams{
+			Response:  resp,
+			Cancel:    func() { _ = pr.Close() },
+			BlockSize: 64,
+		})
+		ids = append(ids, streamId)
+	}
+
+	for _, id := range ids {
+		_, ok := tls_client_cffi_src.GetStream(id)
+		require.True(t, ok, "stream %q not registered before ClearStreamCache", id)
+	}
+
+	tls_client_cffi_src.ClearStreamCache()
+
+	for _, id := range ids {
+		_, ok := tls_client_cffi_src.GetStream(id)
+		assert.False(t, ok, "stream %q still registered after ClearStreamCache", id)
+	}
+
+	for _, pw := range pipes {
+		_ = pw.Close()
+	}
+}
+
+// -----------------------------------------------------------------------------
+// End-to-end: drive a real fhttp client through StartStream + ReadStreamChunk
+// against an httptest server that flushes SSE-style events.
+// -----------------------------------------------------------------------------
+
+func TestStream_EndToEndSSEServer(t *testing.T) {
+	tls_client_cffi_src.ClearStreamCache()
+
+	const eventCount = 3
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("test server must support flushing")
+		}
+		for i := 0; i < eventCount; i++ {
+			fmt.Fprintf(w, "data: event-%d\n\n", i)
+			flusher.Flush()
+			time.Sleep(20 * time.Millisecond)
+		}
+	}))
+	defer server.Close()
+
+	tlsClient, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(),
+		tls_client.WithTimeoutSeconds(10),
+	)
+	require.NoError(t, err, "NewHttpClient")
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	require.NoError(t, err, "NewRequest")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+	t.Cleanup(cancel)
+
+	resp, err := tlsClient.Do(req)
+	require.NoError(t, err, "client.Do")
+
+	streamId := "e2e-sse"
+	tls_client_cffi_src.StartStream(streamId, tls_client_cffi_src.StartStreamParams{
+		Response:  resp,
+		Cancel:    cancel,
+		BlockSize: 4096,
+	})
+	t.Cleanup(func() { tls_client_cffi_src.CancelStream(streamId) })
+
+	var got bytes.Buffer
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		require.False(t, time.Now().After(deadline), "e2e deadline exceeded")
+		out := tls_client_cffi_src.ReadStreamChunk(streamId, 500)
+		require.Empty(t, out.Error, "read error: %s", out.Error)
+		if out.Chunk != "" {
+			got.Write(streamDecodeChunk(t, out))
+		}
+		if out.EOF {
+			break
+		}
+	}
+
+	body := got.String()
+	for i := 0; i < eventCount; i++ {
+		assert.Contains(t, body, fmt.Sprintf("data: event-%d\n\n", i),
+			"missing SSE event %d in assembled stream:\n%s", i, body)
+	}
+}

--- a/tests/stream_to_file_test.go
+++ b/tests/stream_to_file_test.go
@@ -1,0 +1,185 @@
+package tests
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tls_client_cffi_src "github.com/bogdanfinn/tls-client/cffi_src"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin down BuildResponse's StreamOutputPath path. Regression
+// motivation: the body was being routed through charset.NewReader before the
+// stream-to-file write, so binary payloads (images, archives, anything with
+// high-byte content) got silently re-encoded — typically windows-1252 → UTF-8,
+// inflating the file by ~1.6×. The fix skips charset detection when the
+// caller has asked for raw-bytes-to-file behaviour.
+
+// streamOutputInput returns a minimal RequestInput that asks BuildResponse to
+// write the body to streamPath. blockSize is forwarded to the file writer
+// (1 KiB if zero).
+func streamOutputInput(streamPath string, blockSize int) tls_client_cffi_src.RequestInput {
+	in := tls_client_cffi_src.RequestInput{
+		IsByteResponse:   false,
+		StreamOutputPath: &streamPath,
+	}
+	if blockSize > 0 {
+		in.StreamOutputBlockSize = &blockSize
+	}
+	return in
+}
+
+// fakePNG returns a minimal PNG-shaped byte sequence with a generous mix of
+// high-byte values (0x80-0xFF). The exact bytes don't have to be a valid PNG
+// — the test only cares that running them through a UTF-8 charset transcoder
+// would corrupt them, which is true for any sequence with bytes ≥ 0x80
+// outside the UTF-8 grammar.
+func fakePNG(t *testing.T, size int) []byte {
+	t.Helper()
+	require.GreaterOrEqual(t, size, 16, "fakePNG: size must include at least the header")
+	out := make([]byte, size)
+	// PNG signature + a couple of high-byte values that are NOT valid UTF-8
+	// continuation sequences.
+	header := []byte{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A}
+	copy(out, header)
+	for i := len(header); i < size; i++ {
+		// Cycle through 0x80-0xFF — the high-byte range that windows-1252
+		// would "decode" into multi-byte UTF-8 sequences.
+		out[i] = byte(0x80 + (i % 0x80))
+	}
+	return out
+}
+
+func TestBuildResponse_StreamOutputPath_PreservesBinaryBytes(t *testing.T) {
+	// Main regression test: a PNG-shaped binary body with Content-Type:
+	// image/png must be written to disk byte-for-byte, NOT routed through
+	// charset.NewReader.
+	const size = 8192
+	payload := fakePNG(t, size)
+
+	streamPath := filepath.Join(t.TempDir(), "image.png")
+	resp := streamMakeResp(io.NopCloser(bytes.NewReader(payload)), "image/png", "", true)
+
+	out, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, streamOutputInput(streamPath, 1024))
+	require.Nil(t, err, "BuildResponse returned error: %v", err)
+	assert.Equal(t, 200, out.Status)
+
+	written, readErr := os.ReadFile(streamPath)
+	require.NoError(t, readErr, "reading written file")
+	assert.Equal(t, len(payload), len(written), "file length must match input length (would be ~1.6× longer if charset transcoder was applied)")
+	assert.Equal(t, payload, written, "file bytes must match input byte-for-byte")
+}
+
+func TestBuildResponse_StreamOutputPath_LargerBinaryFullySaved(t *testing.T) {
+	// Larger payload that spans many block-write iterations. The previous
+	// charset corruption still showed up here, but a buffered-write bug
+	// could also surface here as truncation; the test pins both.
+	const size = 256 * 1024 // 256 KiB
+	payload := fakePNG(t, size)
+
+	streamPath := filepath.Join(t.TempDir(), "big.bin")
+	resp := streamMakeResp(io.NopCloser(bytes.NewReader(payload)), "image/png", "", true)
+
+	out, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, streamOutputInput(streamPath, 4096))
+	require.Nil(t, err, "BuildResponse returned error: %v", err)
+	assert.Equal(t, 200, out.Status)
+
+	written, readErr := os.ReadFile(streamPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, len(payload), len(written), "file length must match input length")
+	assert.Equal(t, payload, written)
+}
+
+func TestBuildResponse_StreamOutputPath_OctetStreamPreserved(t *testing.T) {
+	// application/octet-stream is the classic "I have no idea what this is,
+	// don't touch it" content type — make sure we still don't touch it.
+	payload := []byte{0xFF, 0xFE, 0x00, 0x01, 0x80, 0x90, 0xA0, 0xB0, 0xC3, 0x28}
+
+	streamPath := filepath.Join(t.TempDir(), "blob.bin")
+	resp := streamMakeResp(io.NopCloser(bytes.NewReader(payload)), "application/octet-stream", "", true)
+
+	_, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, streamOutputInput(streamPath, 1024))
+	require.Nil(t, err)
+
+	written, readErr := os.ReadFile(streamPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, payload, written)
+}
+
+func TestBuildResponse_StreamOutputPath_NoContentTypePreserved(t *testing.T) {
+	// Empty Content-Type is the worst case for the buggy code path: charset
+	// detection sniffs the body itself and may pick something that breaks
+	// binary content. Verify the file write skips charset detection here too.
+	payload := []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0xFF, 0xEE, 0xDD}
+
+	streamPath := filepath.Join(t.TempDir(), "noct.bin")
+	resp := streamMakeResp(io.NopCloser(bytes.NewReader(payload)), "", "", true)
+
+	_, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, streamOutputInput(streamPath, 1024))
+	require.Nil(t, err)
+
+	written, readErr := os.ReadFile(streamPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, payload, written)
+}
+
+func TestBuildResponse_StreamOutputPath_TextResponseStillReachesFile(t *testing.T) {
+	// Sanity check: when the body genuinely is text, the stream-to-file path
+	// still works (we want raw bytes — the caller chose stream-to-file
+	// precisely because they don't want the charset wrapper). Pin the new
+	// behaviour so it's clear: stream-to-file always writes raw bytes,
+	// regardless of Content-Type.
+	const payload = `{"hello":"world","unicode":"ünïçødé"}`
+
+	streamPath := filepath.Join(t.TempDir(), "text.json")
+	resp := streamMakeResp(io.NopCloser(strings.NewReader(payload)), "application/json; charset=utf-8", "", true)
+
+	_, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, streamOutputInput(streamPath, 1024))
+	require.Nil(t, err)
+
+	written, readErr := os.ReadFile(streamPath)
+	require.NoError(t, readErr)
+	assert.Equal(t, []byte(payload), written, "raw UTF-8 bytes should land on disk unchanged")
+}
+
+func TestBuildResponse_StreamOutputPath_EmptyBodyProducesEmptyFile(t *testing.T) {
+	// Empty body must NOT create or write to the file (the !isByteResponse
+	// branch short-circuits via n == 0). Pin the contract so we know exactly
+	// what to expect on disk.
+	streamPath := filepath.Join(t.TempDir(), "empty.bin")
+	resp := streamMakeResp(io.NopCloser(strings.NewReader("")), "image/png", "", true)
+
+	_, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, streamOutputInput(streamPath, 1024))
+	require.Nil(t, err)
+
+	// Either the file was not created (empty body short-circuits) or it
+	// exists with zero length. Both behaviours are acceptable; what's NOT
+	// acceptable is a file containing transcoded garbage.
+	info, statErr := os.Stat(streamPath)
+	if statErr == nil {
+		assert.Equal(t, int64(0), info.Size(), "empty body must not produce non-empty file")
+	} else {
+		assert.True(t, os.IsNotExist(statErr), "unexpected stat error: %v", statErr)
+	}
+}
+
+func TestBuildResponse_NoStreamOutputPath_TextResponseStillUsesCharsetReader(t *testing.T) {
+	// Counterpart sanity: when StreamOutputPath is NOT set, the charset
+	// path still applies. We pin this so the fix doesn't accidentally
+	// disable charset detection for the in-memory text path. The test is
+	// indirect — we just confirm a UTF-8 JSON body comes back as the
+	// expected string.
+	const payload = `{"hello":"world"}`
+	resp := streamMakeResp(io.NopCloser(strings.NewReader(payload)), "application/json; charset=utf-8", "", true)
+
+	input := tls_client_cffi_src.RequestInput{IsByteResponse: false}
+
+	out, err := tls_client_cffi_src.BuildResponse("", false, resp, nil, input)
+	require.Nil(t, err)
+	assert.Equal(t, payload, out.Body)
+}

--- a/tests/timeout_test.go
+++ b/tests/timeout_test.go
@@ -1,0 +1,189 @@
+package tests
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	http "github.com/bogdanfinn/fhttp"
+	"github.com/bogdanfinn/fhttp/httptest"
+	tls_client "github.com/bogdanfinn/tls-client"
+	tls_client_cffi_src "github.com/bogdanfinn/tls-client/cffi_src"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin down the cffi timeout-resolution contract. The motivating
+// regression: callers passing TimeoutSeconds=0 / TimeoutMilliseconds=0 expected
+// "no deadline" (because the underlying tls_client.WithTimeoutSeconds(0)
+// documents 0 as "Unlimited"), but the cffi treated 0 as "field omitted" and
+// silently fell through to DefaultTimeoutSeconds (30s). That made it
+// impossible to consume long-lived SSE streams without hitting a 30 s reset.
+//
+// The fix: a negative value means "disable the deadline". 0 still means
+// "default" so existing callers keep working.
+
+// startSlowServer returns an httptest server whose handler blocks for `delay`
+// before responding 200 OK. Used to provoke client timeouts on demand.
+func startSlowServer(t *testing.T, delay time.Duration) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(delay)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// doWithTimeoutOption builds a client carrying only the option under test plus
+// the bare minimum required by NewHttpClient and runs a GET against url. Returns
+// the elapsed duration and the error (if any). Caller is responsible for
+// closing the response body when err == nil.
+func doWithTimeoutOption(t *testing.T, opt tls_client.HttpClientOption, url string) (time.Duration, error) {
+	t.Helper()
+	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(), opt)
+	require.NoError(t, err, "NewHttpClient")
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	require.NoError(t, err, "NewRequest")
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	elapsed := time.Since(start)
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	return elapsed, err
+}
+
+// isTimeoutErr returns true if err looks like a client-side deadline-exceeded
+// error. Different transports word the message differently.
+func isTimeoutErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "context canceled")
+}
+
+// -----------------------------------------------------------------------------
+// pure unit tests on ResolveTimeoutOption — no network involved.
+// -----------------------------------------------------------------------------
+//
+// We can't directly inspect the time.Duration sitting on the unexported
+// httpClientConfig from the outside, so we verify the option's *effect* by
+// applying it through the public NewHttpClient path and observing whether a
+// slow request times out or not. The expected-behavior matrix is:
+//
+//   sec   ms     | behavior
+//   --------------+----------
+//    0     0     | default 30s   (request to slow server completes well under 30s → no err)
+//   >0     0     | seconds       (deadline)
+//    0    >0     | ms            (deadline)
+//   <0     0     | DISABLED      (long server delay still completes)
+//    0    <0     | DISABLED      (long server delay still completes)
+//   >0    >0     | ms wins       (precedence preserved)
+
+func TestResolveTimeoutOption_BothZero_UsesDefault(t *testing.T) {
+	// Default is 30 s. We can't afford to wait that long, so instead assert
+	// that a fast request (short server delay) completes under default — which
+	// proves "default" did not collapse to 0-disabled by accident, but doesn't
+	// distinguish "default 30 s" from "any other positive value > 50ms". The
+	// stronger assertions below pin the >0 / <0 paths; this one just guards
+	// against a regression where the default branch goes missing entirely.
+	srv := startSlowServer(t, 50*time.Millisecond)
+
+	opt := tls_client_cffi_src.ResolveTimeoutOption(0, 0)
+	elapsed, err := doWithTimeoutOption(t, opt, srv.URL)
+
+	require.NoError(t, err, "default-timeout request must complete (took %v)", elapsed)
+}
+
+func TestResolveTimeoutOption_PositiveSeconds_AppliesDeadline(t *testing.T) {
+	// Server delays 500 ms, deadline is 1 s → must complete.
+	srv := startSlowServer(t, 500*time.Millisecond)
+
+	opt := tls_client_cffi_src.ResolveTimeoutOption(1, 0)
+	elapsed, err := doWithTimeoutOption(t, opt, srv.URL)
+
+	require.NoError(t, err, "expected 1 s deadline to allow a 500 ms request, got err=%v elapsed=%v", err, elapsed)
+}
+
+func TestResolveTimeoutOption_PositiveMilliseconds_AppliesDeadline(t *testing.T) {
+	// Server delays 500 ms, deadline 100 ms → must time out.
+	srv := startSlowServer(t, 500*time.Millisecond)
+
+	opt := tls_client_cffi_src.ResolveTimeoutOption(0, 100)
+	elapsed, err := doWithTimeoutOption(t, opt, srv.URL)
+
+	require.Error(t, err, "expected timeout, got success after %v", elapsed)
+	assert.True(t, isTimeoutErr(err), "expected timeout-shaped error, got: %v", err)
+	// Sanity: timeout should fire well before the server would have finished.
+	assert.Less(t, elapsed, 400*time.Millisecond, "timeout fired too late: %v", elapsed)
+}
+
+func TestResolveTimeoutOption_NegativeSeconds_DisablesDeadline(t *testing.T) {
+	// The bug fix: negative seconds must produce a no-deadline option, so a
+	// server that sleeps longer than the previous default 30s would *also*
+	// complete. We don't actually want to wait 30s in CI, so use a delay
+	// (300 ms) that's:
+	//   - long enough to trip a too-aggressive default
+	//   - short enough that the test stays cheap
+	// and combine with a sanity assertion that the request actually waited.
+	srv := startSlowServer(t, 300*time.Millisecond)
+
+	opt := tls_client_cffi_src.ResolveTimeoutOption(-1, 0)
+	elapsed, err := doWithTimeoutOption(t, opt, srv.URL)
+
+	require.NoError(t, err, "expected request to complete with timeout disabled, got err=%v elapsed=%v", err, elapsed)
+	assert.GreaterOrEqual(t, elapsed, 250*time.Millisecond, "request returned suspiciously fast (%v); did the server actually wait?", elapsed)
+}
+
+func TestResolveTimeoutOption_NegativeMilliseconds_DisablesDeadline(t *testing.T) {
+	// Same contract as the seconds case — pin both branches because they're
+	// independent code paths in the resolver.
+	srv := startSlowServer(t, 300*time.Millisecond)
+
+	opt := tls_client_cffi_src.ResolveTimeoutOption(0, -1)
+	elapsed, err := doWithTimeoutOption(t, opt, srv.URL)
+
+	require.NoError(t, err, "expected request to complete with timeout disabled, got err=%v elapsed=%v", err, elapsed)
+	assert.GreaterOrEqual(t, elapsed, 250*time.Millisecond, "request returned suspiciously fast (%v); did the server actually wait?", elapsed)
+}
+
+func TestResolveTimeoutOption_NegativePrecedesPositive(t *testing.T) {
+	// If either field is negative the resolver must disable the timeout, even
+	// if the other field is a positive deadline that would otherwise apply.
+	// Pin the precedence so a future refactor doesn't accidentally reintroduce
+	// the regression for callers that pass both fields.
+	srv := startSlowServer(t, 300*time.Millisecond)
+
+	// Positive seconds + negative ms → disabled wins over the positive seconds.
+	opt := tls_client_cffi_src.ResolveTimeoutOption(1, -1)
+	_, err := doWithTimeoutOption(t, opt, srv.URL)
+	require.NoError(t, err, "negative ms must disable even when seconds is positive: %v", err)
+}
+
+func TestResolveTimeoutOption_MillisecondsWinOverSeconds(t *testing.T) {
+	// Both positive: ms takes precedence (preserves the original behavior of
+	// the 'if TimeoutMilliseconds != 0' branch overwriting the seconds option).
+	// We pin this so callers that set both fields keep getting the millisecond
+	// resolution.
+	srv := startSlowServer(t, 500*time.Millisecond)
+
+	// Generous seconds (60s) but tight ms (100ms) → ms must win, request times out.
+	opt := tls_client_cffi_src.ResolveTimeoutOption(60, 100)
+	elapsed, err := doWithTimeoutOption(t, opt, srv.URL)
+
+	require.Error(t, err, "expected ms deadline to override seconds; request completed in %v", elapsed)
+	assert.True(t, isTimeoutErr(err), "expected timeout-shaped error, got: %v", err)
+}


### PR DESCRIPTION
> **All code in this PR was written by Claude Code.** My role was
> iterating with it — making sure each fix shipped with regression
> tests and that the cumulative result works in actual production
> use through a downstream .NET wrapper consuming the resulting DLL.

## Summary of changes

Adds streaming response support (SSE / NDJSON / chunked bodies) to the
cffi interface, plus a series of cffi-layer fixes that surfaced while
integrating the resulting DLL into a real .NET wrapper.

### New: streaming exports

Four new c-shared exports let cffi consumers react to bytes as they
arrive instead of waiting for the entire body:

- `requestStream` — sends the request and returns the response
  *headers* (plus a `streamId`) as soon as they arrive; the body keeps
  flowing into a per-stream buffer on the Go side.
- `readStream` — pulls one chunk at a time, with a heartbeat
  `timeoutMs` so the loop can check for cancellation without ever
  blocking forever (`<0` blocks, `=0` non-blocking, `>0` bounded).
- `readStreamAll` — drain the rest of the body in a single call into a
  normal `Response` envelope. Useful when `requestStream` returned but
  the response turned out not to be streaming after all.
- `cancelStream` — tear down a stream early; idempotent, safe in
  `finally`.

Chunks are returned as base64 inside JSON envelopes, matching the rest
of the cffi ABI. `cffi_dist/example_python/example_stream.py`
demonstrates the four exports end-to-end against `httpbin.org/stream/5`.

### Fixes uncovered through downstream usage

Each ships with regression tests that fail against the prior code and
pass against the fix:

- **Empty body for `IsByteResponse=true` requests.** A previous
  refactor (`d0fc595`) moved `io.ReadAll` inside the `!isByteResponse`
  branch and forgot to provide a byte-response branch, so every byte
  response returned an empty payload.
- **`TimeoutSeconds=0` could not actually disable the deadline.** The
  cffi treated 0 as "field omitted" and fell through to
  `DefaultTimeoutSeconds` (30 s), even though the underlying library
  documents `WithTimeoutSeconds(0)` as "unlimited". Use a negative
  sentinel for "disable" so existing zero-value callers keep getting
  the default.
- **`StreamOutputPath` corrupted binary content.** `BuildResponse` ran
  the body through `charset.NewReader` before the stream-to-file write,
  so PNGs and other high-byte content got re-encoded
  windows-1252 → UTF-8 and inflated by ~1.6× (sometimes with a UTF-8
  BOM prepended). Skip the charset wrapper when stream-to-file is
  requested.
- **`WithDebug=true` was silent for Info / Warn / Error.** The
  auto-wrap inside `NewHttpClient` only overrides `Debug()`; with a
  `NewNoopLogger()` base, calls like `c.logger.Warn("you did not setup
  a cookie jar")` were silently dropped. Switch the base to
  `NewLogger()` and bypass the per-session client cache when
  `WithDebug=true` so a previously-cached noop client doesn't win.
- **`SSLKEYLOGFILE` support.** Drop the env var and Wireshark can
  decrypt the cffi caller's TLS to upstream — same convention Chrome /
  curl / Firefox / Go's `crypto/tls` use. Captured exactly once per
  process via `sync.Once`.

### Test coverage

40 new tests across `tests/` and `cffi_src/`:

- 16 streaming tests covering chunk-by-chunk drain, heartbeat timeouts,
  blocking / non-blocking polls, mid-stream errors, cancellation
  idempotence, gzip decompression, plus an end-to-end SSE test against
  an `httptest` server.
- 6 byte-response, 7 timeout-resolution, 7 stream-to-file, 4
  in-package `getTlsClient` tests for `WithDebug` logger / cache
  bypass.

Each fix's regression tests were verified to fail against the unfixed
code via `git stash`-and-rerun before being committed.

### Final notes

- Every commit has a detailed message explaining *why* the change was
  made — the root cause, the regression scenario it fixes, what the
  resulting code contractually guarantees, and (where applicable) the
  verification recipe used to prove the regression test catches the
  bug.
- This PR bundles eight commits. If the scope is too large to land as
  a single unit, the commits are intentionally structured to stand on
  their own: each fix and the streaming feature can be cherry-picked
  or merged in isolation. Pick and choose whichever subset you're
  comfortable taking.