### PR TITLE
fix: http2Conn.Close should return both errors

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -384,14 +384,7 @@ func (h *http2Conn) Write(p []byte) (n int, err error) {
 }
 
 func (h *http2Conn) Close() error {
-	var retErr error = nil
-	if err := h.in.Close(); err != nil {
-		retErr = err
-	}
-	if err := h.out.Close(); err != nil {
-		retErr = err
-	}
-	return retErr
+	return errors.Join(h.in.Close(), h.out.Close())
 }
 
 func (h *http2Conn) CloseConn() error {


### PR DESCRIPTION
http2Conn.Close() overwrites the first error when both inner closes fail. Replaced with errors.Join.