### PR TITLE
fix: guard against nil logger before constructing proxy dialer

### DIFF
--- a/client.go
+++ b/client.go
@@ -106,13 +106,6 @@ func NewHttpClient(logger Logger, options ...HttpClientOption) (HttpClient, erro
 		return nil, err
 	}
 
-	client, dialer, bandwidthTracker, clientProfile, err := buildFromConfig(logger, config)
-	if err != nil {
-		return nil, err
-	}
-
-	config.clientProfile = clientProfile
-
 	if config.debug {
 		if logger == nil {
 			logger = NewLogger()
@@ -124,6 +117,13 @@ func NewHttpClient(logger Logger, options ...HttpClientOption) (HttpClient, erro
 	if logger == nil {
 		logger = NewNoopLogger()
 	}
+
+	client, dialer, bandwidthTracker, clientProfile, err := buildFromConfig(logger, config)
+	if err != nil {
+		return nil, err
+	}
+
+	config.clientProfile = clientProfile
 
 	return &httpClient{
 		Client:           *client,


### PR DESCRIPTION
# tls-client: nil logger crashes proxy CONNECT dialer

Bug report and proposed fix for [`github.com/bogdanfinn/tls-client`](https://github.com/bogdanfinn/tls-client), affecting at least `v1.13.1` and `v1.14.0` (`connect.go` is byte-identical between the two).

## Summary

Passing `nil` as the `logger` argument to `tls_client.NewHttpClient` — which is documented as valid usage in the project README — produces an `httpClient` with a noop logger (safe) but a `connectDialer` with a `nil` logger (unsafe). The connect dialer dereferences `c.logger.Error(...)` unconditionally on a proxy CONNECT deadline, panicking the goroutine and (if not recovered) the process.

## Root cause

In `client.go::NewHttpClient`:

```go
func NewHttpClient(logger Logger, options ...HttpClientOption) (HttpClient, error) {
    ...
    // L99 — buildFromConfig runs with whatever `logger` was passed in,
    // including nil. Inside, newConnectDialer(..., logger) stores the
    // nil into connectDialer.logger.
    client, dialer, bandwidthTracker, clientProfile, err := buildFromConfig(logger, config)
    if err != nil {
        return nil, err
    }
    ...
    // L114 — the nil-check fires AFTER the dialer is already
    // constructed with the nil logger. Only the httpClient gets the
    // replacement; the dialer keeps the nil.
    if logger == nil {
        logger = NewNoopLogger()
    }

    return &httpClient{
        ...
        logger: logger,   // safe noop logger
        dialer: dialer,   // dialer still holds the nil logger
    }, nil
}
```

In `connect.go::connectHttp1` (the closure that handles HTTP/1 CONNECT tunnel responses, named `DialContext.func2` in the binary):

```go
// connect.go:257-265
resp, err := http.ReadResponse(bufio.NewReader(rawConn), req)
if err != nil {
    if errors.Is(err, os.ErrDeadlineExceeded) {
        c.logger.Error("deadline exceeded while trying to read proxy connection")  // ← panic on nil c.logger
    }
    _ = rawConn.Close()
    return nil, err
}
```

The same hazard exists 10 lines up at `connect.go:250` (the `req.Write` deadline path):

```go
if errors.Is(err, os.ErrDeadlineExceeded) {
    c.logger.Error("deadline exceeded while trying to write proxy connection")  // same nil deref
}
```

`SetProxy → applyProxy → newConnectDialer` at `client.go:301` uses `c.logger`, which has been nil-replaced by the time `SetProxy` can be called, so dynamic proxy changes are safe. **The bug is exclusive to the initial `NewHttpClient` constructor path.**

## Repro

The following Go program demonstrates the bug with a hung TCP listener (accepts connections, never responds — the exact shape that triggers `os.ErrDeadlineExceeded` on the CONNECT read).

```go
package main

import (
    "fmt"
    "net"
    "runtime/debug"
    "time"

    tls_client "github.com/bogdanfinn/tls-client"
)

func hungProxy() (string, func()) {
    ln, _ := net.Listen("tcp", "127.0.0.1:0")
    stop := make(chan struct{})
    go func() {
        for {
            conn, err := ln.Accept()
            if err != nil {
                return
            }
            go func(c net.Conn) { <-stop; c.Close() }(conn)
        }
    }()
    return ln.Addr().String(), func() { close(stop); ln.Close() }
}

func run(logger tls_client.Logger, proxyAddr string) string {
    result := make(chan string, 1)
    go func() {
        defer func() {
            if r := recover(); r != nil {
                result <- fmt.Sprintf("PANIC: %v\n%s", r, debug.Stack())
            }
        }()
        client, err := tls_client.NewHttpClient(
            logger,
            tls_client.WithProxyUrl("http://"+proxyAddr),
            tls_client.WithTimeoutSeconds(2),
        )
        if err != nil {
            result <- "construct error: " + err.Error()
            return
        }
        _, err = client.Get("https://example.com")
        if err != nil {
            result <- "request error: " + err.Error()
            return
        }
        result <- "ok"
    }()
    select {
    case r := <-result:
        return r
    case <-time.After(10 * time.Second):
        return "timed out (deadlock?)"
    }
}

func main() {
    addr, stop := hungProxy()
    defer stop()
    fmt.Println("\n=== scenario A: NewHttpClient(nil, ...) ===")
    fmt.Println(run(nil, addr))
    fmt.Println("\n=== scenario B: NewHttpClient(NewNoopLogger(), ...) ===")
    fmt.Println(run(tls_client.NewNoopLogger(), addr))
}
```

Verified output (Go 1.26, Linux, `tls-client v1.14.0`):

```
=== scenario A: NewHttpClient(nil, ...) ===
PANIC: runtime error: invalid memory address or nil pointer dereference
goroutine 9 [running]:
...
github.com/bogdanfinn/tls-client.(*connectDialer).DialContext.func2({...})
	tls-client@v1.14.0/connect.go:260 +0x41b
github.com/bogdanfinn/tls-client.(*connectDialer).DialContext(...)
	tls-client@v1.14.0/connect.go:339 +0xc49
github.com/bogdanfinn/tls-client.(*roundTripper).dialTLS(...)
	tls-client@v1.14.0/roundtripper.go:280 +0x1e4
...

=== scenario B: NewHttpClient(NewNoopLogger(), ...) ===
request error: Get "https://example.com": read tcp 127.0.0.1:xxxxx->127.0.0.1:xxxxx: i/o timeout (Client.Timeout exceeded while awaiting headers)
```

Same code path, same proxy timeout — only difference is the `logger` argument, and only difference in outcome is `panic` vs. clean error return.

A matching production stack trace from a downstream consumer:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x0 pc=0x7ff74c64b73c]

goroutine 735 [running]:
github.com/bogdanfinn/tls-client.(*connectDialer).DialContext.func2({0x7ff74df6a718, 0x339491c021a8})
        tls-client@v1.14.0/connect.go:260 +0x3bc
github.com/bogdanfinn/tls-client.(*connectDialer).DialContext(0x339492c76300, ...)
        tls-client@v1.14.0/connect.go:339 +0x164c
github.com/bogdanfinn/fhttp.(*Transport).customDialTLS(...)
        fhttp@v0.6.8/transport.go:1314 +0xd2
```

Same offset, same line.

## Fix

Move the nil-check + debug-wrap block above `buildFromConfig`:

```diff
 func NewHttpClient(logger Logger, options ...HttpClientOption) (HttpClient, error) {
     config := &httpClientConfig{...}

     for _, opt := range options {
         opt(config)
     }

     if err := validateConfig(config); err != nil {
         return nil, err
     }

+    if config.debug {
+        if logger == nil {
+            logger = NewLogger()
+        }
+        logger = NewDebugLogger(logger)
+    }
+
+    if logger == nil {
+        logger = NewNoopLogger()
+    }
+
     client, dialer, bandwidthTracker, clientProfile, err := buildFromConfig(logger, config)
     if err != nil {
         return nil, err
     }

     config.clientProfile = clientProfile

-    if config.debug {
-        if logger == nil {
-            logger = NewLogger()
-        }
-        logger = NewDebugLogger(logger)
-    }
-
-    if logger == nil {
-        logger = NewNoopLogger()
-    }
-
     return &httpClient{
         Client:           *client,
         logger:           logger,
         config:           config,
         headerLck:        sync.Mutex{},
         bandwidthTracker: bandwidthTracker,
         dialer:           dialer,
     }, nil
 }
```

Moving the block is preferable to adding a redundant nil-check inside `newConnectDialer` itself — it makes the invariant "`logger` is non-nil from this point onward" explicit, and the same fix protects user-supplied `proxyDialerFactory` callers at `client.go:166`, which currently has the same hazard.

## Regression test

Add to `client_test.go` (lives inside the `tls_client` package so it can reach the unexported `connectDialer`):

```go
// TestNewHttpClient_NilLoggerProducesUsableProxyDialer guards against a
// regression where passing nil as the logger argument left the proxy
// dialer with a nil logger, panicking on any CONNECT-deadline path.
func TestNewHttpClient_NilLoggerProducesUsableProxyDialer(t *testing.T) {
    client, err := NewHttpClient(nil, WithProxyUrl("http://127.0.0.1:1"))
    if err != nil {
        t.Fatalf("NewHttpClient: %v", err)
    }
    dialer, ok := client.GetDialer().(*connectDialer)
    if !ok {
        t.Fatalf("expected *connectDialer, got %T", client.GetDialer())
    }
    if dialer.logger == nil {
        t.Fatal("connect dialer's logger is nil — would panic on any CONNECT deadline")
    }
}
```

The behavioral repro above (hung TCP proxy + `recover`) also works as an end-to-end test if a structural test is undesirable.

## Notes

- `connect.go` is byte-identical between `v1.13.1` and `v1.14.0`. The bug exists in at least both versions.
- The project README example (`README.md:61`) reads:
  ```go
  client, _ := tls_client.NewHttpClient(nil, ...)
  ```
  — passing `nil` is the canonical usage in the docs.
- The same pattern affects user-supplied `proxyDialerFactory` callers at `client.go:166`; the proposed fix covers both call sites.
