### PR TITLE
Expose WebSocket support via shared library

### DIFF
--- a/cffi_dist/main.go
+++ b/cffi_dist/main.go
@@ -280,6 +280,124 @@ func request(requestParams *C.char) *C.char {
 	return responseString
 }
 
+//export wsConnect
+func wsConnect(wsConnectParams *C.char) *C.char {
+	wsConnectParamsJson := C.GoString(wsConnectParams)
+
+	wsConnectInput := tls_client_cffi_src.WsConnectInput{}
+	if marshallError := json.Unmarshal([]byte(wsConnectParamsJson), &wsConnectInput); marshallError != nil {
+		return handleErrorResponse("", false, tls_client_cffi_src.NewTLSClientError(marshallError))
+	}
+
+	out, clientErr := tls_client_cffi_src.WsConnect(wsConnectInput)
+	if clientErr != nil {
+		sessionId := ""
+		withSession := false
+		if wsConnectInput.SessionId != nil && *wsConnectInput.SessionId != "" {
+			sessionId = *wsConnectInput.SessionId
+			withSession = true
+		}
+		return handleErrorResponse(sessionId, withSession, clientErr)
+	}
+
+	jsonResponse, marshallError := json.Marshal(out)
+	if marshallError != nil {
+		return handleErrorResponse(out.SessionId, out.SessionId != "", tls_client_cffi_src.NewTLSClientError(marshallError))
+	}
+
+	responseString := C.CString(string(jsonResponse))
+
+	unsafePointersLck.Lock()
+	unsafePointers[out.Id] = responseString
+	unsafePointersLck.Unlock()
+
+	return responseString
+}
+
+//export wsRead
+func wsRead(wsReadParams *C.char) *C.char {
+	wsReadParamsJson := C.GoString(wsReadParams)
+
+	wsReadInput := tls_client_cffi_src.WsReadInput{}
+	if marshallError := json.Unmarshal([]byte(wsReadParamsJson), &wsReadInput); marshallError != nil {
+		return handleErrorResponse("", false, tls_client_cffi_src.NewTLSClientError(marshallError))
+	}
+
+	out, clientErr := tls_client_cffi_src.WsRead(wsReadInput)
+	if clientErr != nil {
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	jsonResponse, marshallError := json.Marshal(out)
+	if marshallError != nil {
+		return handleErrorResponse("", false, tls_client_cffi_src.NewTLSClientError(marshallError))
+	}
+
+	responseString := C.CString(string(jsonResponse))
+
+	unsafePointersLck.Lock()
+	unsafePointers[out.Id] = responseString
+	unsafePointersLck.Unlock()
+
+	return responseString
+}
+
+//export wsWrite
+func wsWrite(wsWriteParams *C.char) *C.char {
+	wsWriteParamsJson := C.GoString(wsWriteParams)
+
+	wsWriteInput := tls_client_cffi_src.WsWriteInput{}
+	if marshallError := json.Unmarshal([]byte(wsWriteParamsJson), &wsWriteInput); marshallError != nil {
+		return handleErrorResponse("", false, tls_client_cffi_src.NewTLSClientError(marshallError))
+	}
+
+	out, clientErr := tls_client_cffi_src.WsWrite(wsWriteInput)
+	if clientErr != nil {
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	jsonResponse, marshallError := json.Marshal(out)
+	if marshallError != nil {
+		return handleErrorResponse("", false, tls_client_cffi_src.NewTLSClientError(marshallError))
+	}
+
+	responseString := C.CString(string(jsonResponse))
+
+	unsafePointersLck.Lock()
+	unsafePointers[out.Id] = responseString
+	unsafePointersLck.Unlock()
+
+	return responseString
+}
+
+//export wsClose
+func wsClose(wsCloseParams *C.char) *C.char {
+	wsCloseParamsJson := C.GoString(wsCloseParams)
+
+	wsCloseInput := tls_client_cffi_src.WsCloseInput{}
+	if marshallError := json.Unmarshal([]byte(wsCloseParamsJson), &wsCloseInput); marshallError != nil {
+		return handleErrorResponse("", false, tls_client_cffi_src.NewTLSClientError(marshallError))
+	}
+
+	out, clientErr := tls_client_cffi_src.WsClose(wsCloseInput)
+	if clientErr != nil {
+		return handleErrorResponse("", false, clientErr)
+	}
+
+	jsonResponse, marshallError := json.Marshal(out)
+	if marshallError != nil {
+		return handleErrorResponse("", false, tls_client_cffi_src.NewTLSClientError(marshallError))
+	}
+
+	responseString := C.CString(string(jsonResponse))
+
+	unsafePointersLck.Lock()
+	unsafePointers[out.Id] = responseString
+	unsafePointersLck.Unlock()
+
+	return responseString
+}
+
 func handleErrorResponse(sessionId string, withSession bool, err *tls_client_cffi_src.TLSClientError) *C.char {
 	response := tls_client_cffi_src.Response{
 		Id:      uuid.New().String(),

--- a/cffi_src/types.go
+++ b/cffi_src/types.go
@@ -204,3 +204,70 @@ type Response struct {
 	UsedProtocol string              `json:"usedProtocol"`
 	Status       int                 `json:"status"`
 }
+
+// WsConnectInput contains the parameters for establishing a WebSocket connection.
+// Either SessionId (to reuse an existing TLS session) or TLSClientIdentifier / CustomTlsClient
+// (to create an inline client) must be provided.
+type WsConnectInput struct {
+	SessionId                    *string          `json:"sessionId"`
+	CustomTlsClient              *CustomTlsClient `json:"customTlsClient"`
+	ProxyUrl                     *string          `json:"proxyUrl"`
+	Url                          string           `json:"url"`
+	TLSClientIdentifier          string           `json:"tlsClientIdentifier"`
+	Headers                      map[string]string `json:"headers"`
+	HeaderOrder                  []string         `json:"headerOrder"`
+	HandshakeTimeoutMilliseconds int              `json:"handshakeTimeoutMilliseconds"`
+	ReadBufferSize               int              `json:"readBufferSize"`
+	WriteBufferSize              int              `json:"writeBufferSize"`
+	InsecureSkipVerify           bool             `json:"insecureSkipVerify"`
+	WithRandomTLSExtensionOrder  bool             `json:"withRandomTLSExtensionOrder"`
+}
+
+// WsConnectOutput is returned after a successful WebSocket handshake.
+type WsConnectOutput struct {
+	Id           string `json:"id"`
+	ConnectionId string `json:"connectionId"`
+	SessionId    string `json:"sessionId,omitempty"`
+	Status       int    `json:"status"`
+}
+
+// WsReadInput contains the parameters for reading a single message from a WebSocket connection.
+type WsReadInput struct {
+	ConnectionId        string `json:"connectionId"`
+	TimeoutMilliseconds int    `json:"timeoutMilliseconds"`
+}
+
+// WsReadOutput contains a message received from a WebSocket connection.
+// MessageType 1 = text, 2 = binary (Data is base64-encoded for binary messages).
+type WsReadOutput struct {
+	Id           string `json:"id"`
+	ConnectionId string `json:"connectionId"`
+	MessageType  int    `json:"messageType"`
+	Data         string `json:"data"`
+}
+
+// WsWriteInput contains the parameters for sending a message over a WebSocket connection.
+// For binary messages (MessageType 2), Data must be base64-encoded.
+type WsWriteInput struct {
+	ConnectionId string `json:"connectionId"`
+	Data         string `json:"data"`
+	MessageType  int    `json:"messageType"`
+}
+
+// WsWriteOutput is returned after sending a WebSocket message.
+type WsWriteOutput struct {
+	Id           string `json:"id"`
+	ConnectionId string `json:"connectionId"`
+	Success      bool   `json:"success"`
+}
+
+// WsCloseInput contains the parameters for closing a WebSocket connection.
+type WsCloseInput struct {
+	ConnectionId string `json:"connectionId"`
+}
+
+// WsCloseOutput is returned after closing a WebSocket connection.
+type WsCloseOutput struct {
+	Id      string `json:"id"`
+	Success bool   `json:"success"`
+}

--- a/cffi_src/websocket.go
+++ b/cffi_src/websocket.go
@@ -1,0 +1,188 @@
+package tls_client_cffi_src
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"time"
+
+	http "github.com/bogdanfinn/fhttp"
+	tls_client "github.com/bogdanfinn/tls-client"
+	"github.com/bogdanfinn/websocket"
+	"github.com/google/uuid"
+)
+
+var wsConnections sync.Map
+
+// WsConnect establishes a WebSocket connection using either an existing session or an inline
+// TLS client configuration. It returns a connectionId that must be used for subsequent
+// WsRead, WsWrite, and WsClose calls.
+//
+// When SessionId is provided the existing TLS client (including its ForceHttp1 setting) is
+// reused. When creating an inline client, HTTP/1.1 is enforced automatically because
+// WebSocket requires it.
+func WsConnect(input WsConnectInput) (WsConnectOutput, *TLSClientError) {
+	var tlsClient tls_client.HttpClient
+	sessionId := ""
+	withSession := false
+
+	if input.SessionId != nil && *input.SessionId != "" {
+		sessionId = *input.SessionId
+		withSession = true
+
+		var err error
+		tlsClient, err = GetClient(sessionId)
+		if err != nil {
+			return WsConnectOutput{}, NewTLSClientError(err)
+		}
+	} else {
+		// Build an inline client. Always enforce HTTP/1.1 since WebSocket requires it.
+		requestInput := RequestInput{
+			TLSClientIdentifier:         input.TLSClientIdentifier,
+			CustomTlsClient:             input.CustomTlsClient,
+			ProxyUrl:                    input.ProxyUrl,
+			ForceHttp1:                  true,
+			InsecureSkipVerify:          input.InsecureSkipVerify,
+			WithRandomTLSExtensionOrder: input.WithRandomTLSExtensionOrder,
+			WithoutCookieJar:            true,
+			FollowRedirects:             false,
+		}
+
+		var clientErr *TLSClientError
+		tlsClient, sessionId, withSession, clientErr = CreateClient(requestInput)
+		if clientErr != nil {
+			return WsConnectOutput{}, clientErr
+		}
+	}
+
+	headers := http.Header{}
+	for k, v := range input.Headers {
+		headers[k] = []string{v}
+	}
+	if len(input.HeaderOrder) > 0 {
+		headers[http.HeaderOrderKey] = input.HeaderOrder
+	}
+
+	wsOptions := []tls_client.WebsocketOption{
+		tls_client.WithTlsClient(tlsClient),
+		tls_client.WithUrl(input.Url),
+		tls_client.WithHeaders(headers),
+	}
+
+	if input.HandshakeTimeoutMilliseconds > 0 {
+		wsOptions = append(wsOptions, tls_client.WithHandshakeTimeoutMilliseconds(input.HandshakeTimeoutMilliseconds))
+	}
+	if input.ReadBufferSize > 0 {
+		wsOptions = append(wsOptions, tls_client.WithReadBufferSize(input.ReadBufferSize))
+	}
+	if input.WriteBufferSize > 0 {
+		wsOptions = append(wsOptions, tls_client.WithWriteBufferSize(input.WriteBufferSize))
+	}
+
+	ws, err := tls_client.NewWebsocket(nil, wsOptions...)
+	if err != nil {
+		return WsConnectOutput{}, NewTLSClientError(fmt.Errorf("failed to create websocket: %w", err))
+	}
+
+	conn, err := ws.Connect(context.Background())
+	if err != nil {
+		return WsConnectOutput{}, NewTLSClientError(fmt.Errorf("failed to connect websocket: %w", err))
+	}
+
+	connectionId := uuid.New().String()
+	wsConnections.Store(connectionId, conn)
+
+	out := WsConnectOutput{
+		Id:           uuid.New().String(),
+		ConnectionId: connectionId,
+		Status:       101,
+	}
+	if withSession {
+		out.SessionId = sessionId
+	}
+
+	return out, nil
+}
+
+// WsRead reads a single message from an active WebSocket connection.
+// If TimeoutMilliseconds is > 0 a read deadline is applied for that call.
+// Text messages are returned as-is; binary messages are base64-encoded.
+func WsRead(input WsReadInput) (WsReadOutput, *TLSClientError) {
+	val, ok := wsConnections.Load(input.ConnectionId)
+	if !ok {
+		return WsReadOutput{}, NewTLSClientError(fmt.Errorf("no websocket connection found for connectionId: %s", input.ConnectionId))
+	}
+
+	conn := val.(*websocket.Conn)
+
+	if input.TimeoutMilliseconds > 0 {
+		conn.SetReadDeadline(time.Now().Add(time.Duration(input.TimeoutMilliseconds) * time.Millisecond))
+	}
+
+	mt, msg, err := conn.ReadMessage()
+	if err != nil {
+		return WsReadOutput{}, NewTLSClientError(fmt.Errorf("failed to read message: %w", err))
+	}
+
+	data := string(msg)
+	if mt == websocket.BinaryMessage {
+		data = base64.StdEncoding.EncodeToString(msg)
+	}
+
+	return WsReadOutput{
+		Id:           uuid.New().String(),
+		ConnectionId: input.ConnectionId,
+		MessageType:  mt,
+		Data:         data,
+	}, nil
+}
+
+// WsWrite sends a message over an active WebSocket connection.
+// For binary messages (MessageType 2) the Data field must be base64-encoded.
+func WsWrite(input WsWriteInput) (WsWriteOutput, *TLSClientError) {
+	val, ok := wsConnections.Load(input.ConnectionId)
+	if !ok {
+		return WsWriteOutput{}, NewTLSClientError(fmt.Errorf("no websocket connection found for connectionId: %s", input.ConnectionId))
+	}
+
+	conn := val.(*websocket.Conn)
+
+	var msgData []byte
+	if input.MessageType == websocket.BinaryMessage {
+		var decodeErr error
+		msgData, decodeErr = base64.StdEncoding.DecodeString(input.Data)
+		if decodeErr != nil {
+			return WsWriteOutput{}, NewTLSClientError(fmt.Errorf("failed to base64 decode binary message: %w", decodeErr))
+		}
+	} else {
+		msgData = []byte(input.Data)
+	}
+
+	if writeErr := conn.WriteMessage(input.MessageType, msgData); writeErr != nil {
+		return WsWriteOutput{}, NewTLSClientError(fmt.Errorf("failed to write message: %w", writeErr))
+	}
+
+	return WsWriteOutput{
+		Id:           uuid.New().String(),
+		ConnectionId: input.ConnectionId,
+		Success:      true,
+	}, nil
+}
+
+// WsClose closes an active WebSocket connection and removes it from the connection store.
+func WsClose(input WsCloseInput) (WsCloseOutput, *TLSClientError) {
+	val, ok := wsConnections.Load(input.ConnectionId)
+	if !ok {
+		return WsCloseOutput{}, NewTLSClientError(fmt.Errorf("no websocket connection found for connectionId: %s", input.ConnectionId))
+	}
+
+	conn := val.(*websocket.Conn)
+	conn.Close()
+	wsConnections.Delete(input.ConnectionId)
+
+	return WsCloseOutput{
+		Id:      uuid.New().String(),
+		Success: true,
+	}, nil
+}


### PR DESCRIPTION
## Summary

Closes #240.

Exposes the WebSocket functionality (added in v1.14.0) through the CFFI shared library so non-Go consumers (C#, Python, Node.js, Rust, …) can open fingerprinted WebSocket connections without rebuilding the TLS stack.

Four new `//export`ed entry points in `cffi_dist/main.go`, backed by a new `cffi_src/websocket.go`:

| Export | Purpose |
|---|---|
| `wsConnect` | Open a WebSocket. Accepts either an existing `sessionId` (reuses the TLS client) or an inline `tlsClientIdentifier` / `customTlsClient`. Returns a `connectionId` UUID. |
| `wsRead` | Blocking read with optional `timeoutMilliseconds`. Returns `messageType` (1=text, 2=binary) and `data` (base64-encoded for binary). |
| `wsWrite` | Send a text or binary message. Binary `data` must be base64-encoded. |
| `wsClose` | Close the connection and free its slot in the connection map. |

All four responses include the standard `id` UUID and integrate with the existing `freeMemory()` lifecycle.

## Implementation notes

- Connections are stored in a `sync.Map` keyed by `connectionId`, mirroring the HTTP session cache pattern.
- Inline clients are constructed with `forceHttp1: true` and `withoutCookieJar: true` since WebSocket requires HTTP/1.1.
- Existing-session reuse does **not** mutate the client — callers must create the session with `forceHttp1: true` if they intend to upgrade it to WebSocket. Mutating an in-flight client would break concurrent HTTP requests, so this is left to the caller (documented in the `WsConnect` doc comment).
- Binary message payloads use `base64.StdEncoding` on both read and write paths.
- Header ordering is supported via `headerOrder` (passed through `http.HeaderOrderKey` exactly like the HTTP request path).
- Error responses go through the existing `handleErrorResponse` so consumers see the same shape they're used to.

## Files changed

- `cffi_src/websocket.go` (new) — `WsConnect` / `WsRead` / `WsWrite` / `WsClose`
- `cffi_src/types.go` — 8 new structs for the WS in/out payloads
- `cffi_dist/main.go` — 4 new CFFI exports