### PR TITLE
fix: close idle connections when clearing session cache

### DIFF
--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -45,7 +45,10 @@ func ClearSessionCache() {
 	clientsLock.Lock()
 	defer clientsLock.Unlock()
 
-	// the remaining clients will be cleaned up by the garbage collection
+	for _, client := range clients {
+		client.CloseIdleConnections()
+	}
+
 	clients = make(map[string]tls_client.HttpClient)
 }
 


### PR DESCRIPTION
## Summary
`ClearSessionCache` now closes idle connections on all cached clients before discarding them, matching the behavior already present in `RemoveSession`.

## Problem
Previously, `ClearSessionCache` only replaced the clients map with a new empty one, leaving idle TCP connections open until GC eventually collected the discarded `HttpClient` objects. This could lead to resource exhaustion (file descriptors, ephemeral ports) under high churn.

## Fix
Iterate over all clients and call `CloseIdleConnections()` before clearing the map — consistent with how `RemoveSession` handles single-client removal.

## Testing
Verified manually. No functional change to existing behavior — the map is still emptied after the loop.