### PR TITLE
feat: add forcedEncoding option to specify charset for response body

### DIFF
--- a/cffi_dist/example_csharp/Requester.cs
+++ b/cffi_dist/example_csharp/Requester.cs
@@ -26,6 +26,7 @@ class RequestPayload
     public bool WithoutCookieJar { get; set; } = false;
     public bool WithCustomCookieJar { get; set; } = false;
     public bool IsByteRequest { get; set; } = false;
+    public string ForcedEncoding { get; set; } = "";
     public bool ForceHttp1 { get; set; } = false;
     public bool WithDebug { get; set; } = false;
     public bool CatchPanics { get; set; } = false;

--- a/cffi_dist/example_typescript/src/types.ts
+++ b/cffi_dist/example_typescript/src/types.ts
@@ -19,6 +19,7 @@ export interface TLSClientRequestPayload {
     followRedirects?: boolean;
     insecureSkipVerify?: boolean;
     isByteResponse?: boolean;
+    forcedEncoding?: string;
     withoutCookieJar?: boolean;
     withRandomTLSExtensionOrder?: boolean;
     timeoutSeconds?: number;

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -231,7 +231,11 @@ func BuildResponse(sessionId string, withSession bool, resp *http.Response, cook
 		} else {
 			bodyReader = io.MultiReader(bytes.NewReader(firstByte[:n]), resp.Body)
 			// Automatically detect the charset for non-byte responses
-			bodyReader, err = charset.NewReader(bodyReader, ct)
+			if input.ForcedEncoding != nil && *input.ForcedEncoding != "" {
+				bodyReader, err = charset.NewReaderLabel(*input.ForcedEncoding, bodyReader)
+			} else {
+				bodyReader, err = charset.NewReader(bodyReader, ct)
+			}
 			if err != nil {
 				return Response{}, NewTLSClientError(err)
 			}

--- a/cffi_src/factory_test.go
+++ b/cffi_src/factory_test.go
@@ -1,0 +1,115 @@
+package tls_client_cffi_src
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+)
+
+func TestBuildResponse_ForcedEncoding_GBK(t *testing.T) {
+	gbkBytes := []byte{0xc4, 0xe3, 0xba, 0xc3}
+	utf8Expected := "你好"
+
+	encoding := "gbk"
+	reqInput := RequestInput{
+		RequestMethod: "GET",
+		RequestUrl:    "http://example.com",
+		ForcedEncoding: &encoding,
+	}
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+		Body:       io.NopCloser(bytes.NewReader(gbkBytes)),
+	}
+
+	result, err := BuildResponse("", false, resp, nil, reqInput)
+	if err != nil {
+		t.Fatalf("BuildResponse error: %v", err)
+	}
+
+	if result.Body != utf8Expected {
+		t.Fatalf("expected body %q, got %q", utf8Expected, result.Body)
+	}
+}
+
+func TestBuildResponse_ForcedEncoding_Empty(t *testing.T) {
+	gbkBytes := []byte{0xc4, 0xe3, 0xba, 0xc3}
+	utf8Expected := "你好"
+
+	encoding := ""
+	reqInput := RequestInput{
+		RequestMethod: "GET",
+		RequestUrl:    "http://example.com",
+		ForcedEncoding: &encoding,
+	}
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html; charset=gbk"}},
+		Body:       io.NopCloser(bytes.NewReader(gbkBytes)),
+	}
+
+	result, err := BuildResponse("", false, resp, nil, reqInput)
+	if err != nil {
+		t.Fatalf("BuildResponse error: %v", err)
+	}
+
+	if result.Body != utf8Expected {
+		t.Fatalf("expected body %q, got %q", utf8Expected, result.Body)
+	}
+}
+
+func TestBuildResponse_AutoDetectFromHeader(t *testing.T) {
+	gbkBytes := []byte{0xc4, 0xe3, 0xba, 0xc3}
+	utf8Expected := "你好"
+
+	reqInput := RequestInput{
+		RequestMethod: "GET",
+		RequestUrl:    "http://example.com",
+	}
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html; charset=gbk"}},
+		Body:       io.NopCloser(bytes.NewReader(gbkBytes)),
+	}
+
+	result, err := BuildResponse("", false, resp, nil, reqInput)
+	if err != nil {
+		t.Fatalf("BuildResponse error: %v", err)
+	}
+
+	if result.Body != utf8Expected {
+		t.Fatalf("expected body %q, got %q", utf8Expected, result.Body)
+	}
+}
+
+func TestBuildResponse_ForcedEncoding_UTF8(t *testing.T) {
+	utf8Bytes := []byte{0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd}
+	utf8Expected := "你好"
+
+	encoding := "utf-8"
+	reqInput := RequestInput{
+		RequestMethod: "GET",
+		RequestUrl:    "http://example.com",
+		ForcedEncoding: &encoding,
+	}
+
+	resp := &http.Response{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"text/html"}},
+		Body:       io.NopCloser(bytes.NewReader(utf8Bytes)),
+	}
+
+	result, err := BuildResponse("", false, resp, nil, reqInput)
+	if err != nil {
+		t.Fatalf("BuildResponse error: %v", err)
+	}
+
+	if result.Body != utf8Expected {
+		t.Fatalf("expected body %q, got %q", utf8Expected, result.Body)
+	}
+}

--- a/cffi_src/types.go
+++ b/cffi_src/types.go
@@ -79,6 +79,7 @@ type RequestInput struct {
 	InsecureSkipVerify          bool                `json:"insecureSkipVerify"`
 	IsByteRequest               bool                `json:"isByteRequest"`
 	IsByteResponse              bool                `json:"isByteResponse"`
+	ForcedEncoding              *string             `json:"forcedEncoding"`
 	IsRotatingProxy             bool                `json:"isRotatingProxy"`
 	DisableIPV6                 bool                `json:"disableIPV6"`
 	DisableIPV4                 bool                `json:"disableIPV4"`


### PR DESCRIPTION
## Summary
Add `forcedEncoding` option to `RequestInput`, allowing callers to explicitly specify the charset for decoding the response body, bypassing auto-detection from `Content-Type`.

## Problem
`BuildResponse` uses `charset.NewReader` which auto-detects encoding from the `Content-Type` header. Some servers serve content with a wrong or missing charset declaration (e.g. GBK content labeled as `text/html` without charset), causing garbled output.

## Fix
* `RequestInput` gains a `ForcedEncoding *string` field.
* In `BuildResponse`: when `forcedEncoding` is set and non-empty, use `charset.NewReaderLabel` with the specified encoding; otherwise fall back to the existing auto-detect behavior.
* Updated TypeScript and C# example clients with the new field.

## Testing
4 unit tests added in `cffi_src/factory_test.go`, all passing:
* GBK content decoded with `forcedEncoding`: `"gbk"`
* GBK content decoded via `Content-Type` header when `forcedEncoding` is empty string
* GBK content auto-detected from header when `forcedEncoding` is `nil`
* UTF-8 content with explicit `forcedEncoding`: `"utf-8"`