### PR TITLE
fix: connection leak & logging format

### DIFF
--- a/client.go
+++ b/client.go
@@ -316,7 +316,7 @@ func (c *httpClient) SetProxy(proxyUrl string) error {
 
 	err := c.applyProxy()
 	if err != nil {
-		c.logger.Error("failed to apply new proxy. rolling back to previous used proxy: %w", err)
+		c.logger.Error("failed to apply new proxy. rolling back to previous used proxy: %v", err)
 		c.config.proxyUrl = currentProxy
 
 		return c.applyProxy()

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -316,6 +316,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 	err = rt.certificatePinner.Pin(conn, host)
 
 	if err != nil {
+		_ = conn.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixed an edgecase with roundtripper where the roundtripper didn't close an connection on pinning failure
Fixed on log which used an logging format that doesn't exist (probably a typo)