### PR TITLE
fix: inject GREASE setting in HTTP/2 SETTINGS frame for Chrome profiles

### DIFF
--- a/roundtripper.go
+++ b/roundtripper.go
@@ -214,6 +214,32 @@ func profileDefaultMaxResponseHeaderBytes(cfg *http3Config) int {
 	return -1
 }
 
+// applyH2GreaseSetting appends a random GREASE setting to the HTTP/2 settings map
+// and order for Chrome profiles, mirroring the HTTP/3 path in buildHTTP3Transport.
+// Real Chrome sends a GREASE entry in its HTTP/2 SETTINGS frame; Firefox does not.
+// The GREASE setting is placed at the end of the settings list, matching real
+// Chrome's frame order. The input map and slice are not mutated.
+func applyH2GreaseSetting(settings map[http2.SettingID]uint32, settingsOrder []http2.SettingID, isChrome bool) (map[http2.SettingID]uint32, []http2.SettingID) {
+	if !isChrome {
+		return settings, settingsOrder
+	}
+
+	greaseID := http2.SettingID(generateH2GreaseSettingID())
+	greaseValue := uint32(generateGREASESettingValue())
+
+	withGrease := make(map[http2.SettingID]uint32, len(settings)+1)
+	for k, v := range settings {
+		withGrease[k] = v
+	}
+	withGrease[greaseID] = greaseValue
+
+	orderWithGrease := make([]http2.SettingID, len(settingsOrder)+1)
+	copy(orderWithGrease, settingsOrder)
+	orderWithGrease[len(settingsOrder)] = greaseID
+
+	return withGrease, orderWithGrease
+}
+
 func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	addr := rt.getDialTLSAddr(req)
 
@@ -405,6 +431,13 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 			t2.Settings = rt.settings
 			t2.SettingsOrder = rt.settingsOrder
 		}
+
+		// Add a random GREASE setting for Chrome profiles, mirroring the HTTP/3 path
+		// in buildHTTP3Transport. Real Chrome sends a GREASE entry in its HTTP/2
+		// SETTINGS frame; Firefox does not. The GREASE setting is appended at the end
+		// of the settings list, matching real Chrome's frame order and the H3
+		// implementation. The input map and slice are not mutated.
+		t2.Settings, t2.SettingsOrder = applyH2GreaseSetting(t2.Settings, t2.SettingsOrder, rt.clientHelloId.Client == "Chrome")
 
 		t2.Priorities = rt.priorities
 

--- a/roundtripper_test.go
+++ b/roundtripper_test.go
@@ -1,0 +1,100 @@
+package tls_client
+
+import (
+	"testing"
+
+	"github.com/bogdanfinn/fhttp/http2"
+)
+
+// rfc8701H2GreaseIDs are the reserved 16-bit GREASE values per RFC 8701.
+var rfc8701H2GreaseIDs = map[http2.SettingID]bool{
+	0x0a0a: true, 0x1a1a: true, 0x2a2a: true, 0x3a3a: true,
+	0x4a4a: true, 0x5a5a: true, 0x6a6a: true, 0x7a7a: true,
+	0x8a8a: true, 0x9a9a: true, 0xaaaa: true, 0xbaba: true,
+	0xcaca: true, 0xdada: true, 0xeaea: true, 0xfafa: true,
+}
+
+func TestApplyH2GreaseSetting_Chrome(t *testing.T) {
+	base := map[http2.SettingID]uint32{
+		http2.SettingHeaderTableSize:   65536,
+		http2.SettingEnablePush:        0,
+		http2.SettingInitialWindowSize: 6291456,
+		http2.SettingMaxHeaderListSize: 262144,
+	}
+	baseOrder := []http2.SettingID{
+		http2.SettingHeaderTableSize,
+		http2.SettingEnablePush,
+		http2.SettingInitialWindowSize,
+		http2.SettingMaxHeaderListSize,
+	}
+
+	got, gotOrder := applyH2GreaseSetting(base, baseOrder, true)
+
+	// All original settings preserved.
+	for k, v := range base {
+		if got[k] != v {
+			t.Errorf("setting %d changed: got %d, want %d", k, got[k], v)
+		}
+	}
+
+	// Exactly one GREASE entry appended at the end.
+	if len(gotOrder) != len(baseOrder)+1 {
+		t.Fatalf("order length: got %d, want %d", len(gotOrder), len(baseOrder)+1)
+	}
+	greaseID := gotOrder[len(baseOrder)]
+	if !rfc8701H2GreaseIDs[greaseID] {
+		t.Errorf("appended setting ID 0x%04x is not a valid RFC 8701 GREASE value", greaseID)
+	}
+	greaseVal, ok := got[greaseID]
+	if !ok {
+		t.Fatalf("GREASE setting %d not present in settings map", greaseID)
+	}
+	if greaseVal == 0 {
+		t.Errorf("GREASE setting value must be non-zero, got 0")
+	}
+
+	// Original settings order preserved as a prefix.
+	for i, id := range baseOrder {
+		if gotOrder[i] != id {
+			t.Errorf("order[%d]: got %d, want %d", i, gotOrder[i], id)
+		}
+	}
+
+	// Original map and slice must not be mutated.
+	if _, ok := base[greaseID]; ok {
+		t.Errorf("original settings map was mutated with GREASE entry")
+	}
+	if len(baseOrder) != 4 {
+		t.Errorf("original settingsOrder was mutated: got len %d, want 4", len(baseOrder))
+	}
+}
+
+func TestApplyH2GreaseSetting_NonChrome(t *testing.T) {
+	base := map[http2.SettingID]uint32{
+		http2.SettingHeaderTableSize:   65536,
+		http2.SettingEnablePush:        0,
+		http2.SettingInitialWindowSize: 131072,
+		http2.SettingMaxFrameSize:      16384,
+	}
+	baseOrder := []http2.SettingID{
+		http2.SettingHeaderTableSize,
+		http2.SettingEnablePush,
+		http2.SettingInitialWindowSize,
+		http2.SettingMaxFrameSize,
+	}
+
+	got, gotOrder := applyH2GreaseSetting(base, baseOrder, false)
+
+	// Non-Chrome profiles must receive no GREASE: returned unchanged.
+	if len(got) != len(base) {
+		t.Errorf("settings map size changed: got %d, want %d", len(got), len(base))
+	}
+	if len(gotOrder) != len(baseOrder) {
+		t.Errorf("order length changed: got %d, want %d", len(gotOrder), len(baseOrder))
+	}
+	for _, id := range gotOrder {
+		if rfc8701H2GreaseIDs[id] {
+			t.Errorf("non-Chrome profile received GREASE setting 0x%04x", id)
+		}
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -37,3 +37,15 @@ func generateGREASESettingValue() uint64 {
 	}
 	return uint64(val)
 }
+
+// generateH2GreaseSettingID generates a valid 16-bit GREASE setting ID for HTTP/2.
+// Per RFC 8701, the reserved 16-bit GREASE values are 0x0a0a, 0x1a1a, ..., 0xfafa
+// (both bytes equal, each of the form 0xN0x0a where N is 0..15). Real Chrome
+// randomly picks one of these per connection for its HTTP/2 SETTINGS frame.
+// HTTP/2 setting IDs are 16-bit, so this differs from the HTTP/3 path which uses
+// large varint GREASE IDs (see generateGREASESettingID).
+func generateH2GreaseSettingID() uint16 {
+	nBig, _ := rand.Int(rand.Reader, big.NewInt(16))
+	b := uint8(0x0a) + uint8(nBig.Uint64())*0x10
+	return uint16(b)<<8 | uint16(b)
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,6 +5,31 @@ import (
 	"testing"
 )
 
+func TestGenerateH2GreaseSettingID(t *testing.T) {
+	// RFC 8701 reserved 16-bit GREASE values: 0x0a0a, 0x1a1a, ..., 0xfafa
+	validGrease := map[uint16]bool{
+		0x0a0a: true, 0x1a1a: true, 0x2a2a: true, 0x3a3a: true,
+		0x4a4a: true, 0x5a5a: true, 0x6a6a: true, 0x7a7a: true,
+		0x8a8a: true, 0x9a9a: true, 0xaaaa: true, 0xbaba: true,
+		0xcaca: true, 0xdada: true, 0xeaea: true, 0xfafa: true,
+	}
+
+	seen := map[uint16]bool{}
+	for i := 0; i < 1000; i++ {
+		id := generateH2GreaseSettingID()
+		if !validGrease[id] {
+			t.Errorf("generated non-RFC-8701 GREASE setting ID: 0x%04x", id)
+		}
+		seen[id] = true
+	}
+
+	// 1000 draws from 16 values should produce more than one distinct value,
+	// confirming the ID is randomized per call (real Chrome randomizes per connection).
+	if len(seen) < 2 {
+		t.Errorf("expected randomized GREASE IDs, got %d distinct value(s)", len(seen))
+	}
+}
+
 func TestInt64ToInt(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Closes #260.

Mirrors the HTTP/3 GREASE injection from #215 in the HTTP/2 path. For Chrome profiles a random RFC 8701 GREASE setting is appended to the SETTINGS frame after the real settings, matching the order real Chrome sends. Non-Chrome profiles are untouched.

H2 setting IDs are `uint16`, so this uses the 16-bit GREASE values (`0x0a0a` through `0xfafa`) rather than the varint IDs `generateGREASESettingID` produces. Value generation reuses `generateGREASESettingValue()`.

Chrome is detected via `clientHelloId.Client == "Chrome"` rather than the H3 path's `http3PriorityParam > 0` check. That check works as an H3-layer proxy because only the profiles with H3 fields carry it, but Chrome_150 has none, and real Chrome 150 does send H2 GREASE.

The helper copies the settings map and order rather than mutating what it's given, since profile settings are shared across clients.

Tests cover RFC 8701 conformance, randomisation across calls, that the entry lands last, and that non-Chrome profiles get nothing added.

`go test .` passes. The failures under `tests/` are pre-existing live-network cases (httpbin.org returning 503, and similar); I re-ran them on a clean checkout to confirm they fail there too.
