### PR TITLE
Add Chrome 152 and Chrome 152 PSK profiles, trust_anchors payload, tests

### DIFF
--- a/profiles/extension_data.go
+++ b/profiles/extension_data.go
@@ -1,0 +1,110 @@
+package profiles
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"math/big"
+)
+
+// Captured payloads for the trust_anchors extension (0xca34). A payload is a
+// RequestedTrustAnchorList: a 16-bit list length, then an 8-bit length and an
+// ID per anchor.
+// https://source.chromium.org/search?q=TLSEXT_TYPE_trust_anchors
+// https://issues.chromium.org/issues/398275713
+//
+// To add a capture for a new browser version:
+//
+//  1. Open https://tls.peet.ws/api/all in that browser, or in a local container
+//     that runs the same service.
+//  2. In the tls.extensions array, find the entry named "Unknown extension
+//     51764" and copy its data field. The field is the payload in hex and it
+//     starts at the 16-bit list length, so copy it whole.
+//  3. Add a const with the hex string and a payload var next to the entries
+//     below. The var fails at package load if the payload is malformed, so a
+//     wrong copy shows at once.
+//  4. Pass the payload var as the extension data in the profile.
+
+// Stable Chrome 152.0.7977.64 Android. 186 bytes, 28 IDs, Chrome Root Store 39,
+// no MTC anchors.
+const chrome152TrustAnchorsCapture = "00b80582df13020108839a648c9b2d010c08839a648c9b2d010704d679090c08839a648c9b2d010a04d679090b08839a648c9b2d010d0582df13020e08839a648c9b2d010b04d67909050582df13020d0582df13021404d679090404d679090804d679090d04d679090a04d679090708839a648c9b2d011204d67909010582df13020608839a648c9b2d01080582df13021208839a648c9b2d011304d679090f0582df13021308839a648c9b2d01090582df13020f04d6790906"
+
+var chrome152TrustAnchors = shuffleTrustAnchors(mustSplitTrustAnchors(chrome152TrustAnchorsCapture))
+
+// mustDecodeHex converts a wire-format hex string into extension data. It
+// panics on malformed input, which can only come from a literal in this
+// package.
+func mustDecodeHex(s string) []byte {
+	data, err := hex.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}
+
+// mustSplitTrustAnchors splits a captured payload into records. A record is the
+// 8-bit length with the ID that follows it, so records reorder without further
+// parsing. It panics on malformed input, which can only come from a literal in
+// this package.
+func mustSplitTrustAnchors(capture string) [][]byte {
+	payload := mustDecodeHex(capture)
+	if len(payload) < 2 {
+		panic("trust anchors payload is shorter than its length field")
+	}
+
+	list := payload[2:]
+	if int(payload[0])<<8|int(payload[1]) != len(list) {
+		panic("trust anchors length field does not match the list")
+	}
+
+	var records [][]byte
+
+	for i := 0; i < len(list); {
+		end := i + 1 + int(list[i])
+		if end > len(list) {
+			panic("trust anchor ID runs past the end of the list")
+		}
+
+		records = append(records, list[i:end])
+		i = end
+	}
+
+	return records
+}
+
+// shuffleTrustAnchors builds the trust_anchors payload from the given records
+// and gives them a new order. Chromium writes the IDs in absl::flat_hash_set
+// iteration order, which holds for the life of the process and differs between
+// processes. The callers above therefore shuffle once at package load, so one
+// program run keeps one order and two runs differ.
+//
+// It panics if the random source fails, which crypto/rand does not survive
+// either.
+func shuffleTrustAnchors(anchors [][]byte) []byte {
+	records := make([][]byte, len(anchors))
+	copy(records, anchors)
+
+	for i := len(records) - 1; i > 0; i-- {
+		j, err := rand.Int(rand.Reader, big.NewInt(int64(i+1)))
+		if err != nil {
+			panic(err)
+		}
+
+		records[i], records[j.Int64()] = records[j.Int64()], records[i]
+	}
+
+	size := 0
+	for _, record := range records {
+		size += len(record)
+	}
+
+	payload := make([]byte, 2, 2+size)
+	binary.BigEndian.PutUint16(payload, uint16(size))
+
+	for _, record := range records {
+		payload = append(payload, record...)
+	}
+
+	return payload
+}

--- a/profiles/grease.go
+++ b/profiles/grease.go
@@ -1,0 +1,61 @@
+package profiles
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+
+	tls "github.com/bogdanfinn/utls"
+)
+
+// randomGREASESignatureScheme returns a random GREASE value for the
+// signature_algorithms extension.
+//
+// Chrome sends a GREASE value as its first signature algorithm and picks a new
+// one for every connection. utls replaces GREASE placeholders in the cipher
+// suites, the supported groups, the key shares, the supported versions and the
+// GREASE extensions, but not in signature_algorithms. The value is therefore
+// chosen here. A SpecFactory runs once per connection, so every connection gets
+// its own value.
+//
+// The result has the form 0xWaWa for 0 <= W < 16, which is how BoringSSL builds
+// its GREASE values. It panics if the random source fails, which crypto/rand
+// does not survive either.
+// https://github.com/google/boringssl/blob/master/ssl/handshake_client.cc
+//
+// This function is a workaround. The proper fix belongs upstream in utls
+// (currently github.com/bogdanfinn/utls v1.7.7-barnius) and needs three
+// changes:
+//
+//  1. In u_tls_extensions.go, add a GREASE index for signature algorithms to
+//     the const block that starts at ssl_grease_cipher. Put the new name ahead
+//     of ssl_grease_ticket_extension so that ssl_grease_last_index, and with it
+//     the greaseSeed array on UConn, grows by one.
+//  2. In u_parrots.go, add a "case *SignatureAlgorithmsExtension" to the switch
+//     over uconn.Extensions inside ApplyPreset, next to the existing
+//     SupportedCurvesExtension, KeyShareExtension and SupportedVersionsExtension
+//     cases. Replace every entry for which isGREASEUint16 reports true with
+//     GetBoringGREASEValue(uconn.greaseSeed, <the new index>), which is what
+//     those three cases already do.
+//  3. Once utls does the substitution, delete this function and write
+//     tls.SignatureScheme(tls.GREASE_PLACEHOLDER) in the profile instead, the
+//     same way the cipher suites, the supported groups, the key shares and the
+//     supported versions already express GREASE.
+//
+// The upstream fix is more faithful than this function. utls derives every
+// GREASE value in one ClientHello from a single per-connection seed, so the
+// values relate to each other the way BoringSSL makes them relate. The value
+// returned here is drawn independently of that seed, so it can collide with the
+// GREASE value in another position, which real Chrome makes less likely.
+func randomGREASESignatureScheme() tls.SignatureScheme {
+	var seed [2]byte
+
+	if _, err := rand.Read(seed[:]); err != nil {
+		panic(err)
+	}
+
+	value := binary.LittleEndian.Uint16(seed[:])
+	value = (value & 0xf0) | 0x0a
+	value |= value << 8
+
+	return tls.SignatureScheme(value)
+}

--- a/profiles/internal_browser_profiles.go
+++ b/profiles/internal_browser_profiles.go
@@ -5,6 +5,245 @@ import (
 	tls "github.com/bogdanfinn/utls"
 )
 
+var Chrome_152_PSK = ClientProfile{
+	clientHelloId: tls.ClientHelloID{
+		Client:               "Chrome",
+		RandomExtensionOrder: false,
+		Version:              "152_PSK",
+		Seed:                 nil,
+		SpecFactory: func() (tls.ClientHelloSpec, error) {
+			return tls.ClientHelloSpec{
+				CipherSuites: []uint16{
+					tls.GREASE_PLACEHOLDER,
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+				},
+				CompressionMethods: []byte{
+					tls.CompressionNone,
+				},
+				Extensions: []tls.TLSExtension{
+					&tls.UtlsGREASEExtension{},
+					&tls.ApplicationSettingsExtensionNew{
+						SupportedProtocols: []string{"h2"},
+					},
+					&tls.SupportedVersionsExtension{Versions: []uint16{
+						tls.GREASE_PLACEHOLDER,
+						tls.VersionTLS13,
+						tls.VersionTLS12,
+					}},
+					&tls.SCTExtension{},
+					tls.BoringGREASEECH(),
+					&tls.KeyShareExtension{KeyShares: []tls.KeyShare{
+						{Group: tls.CurveID(tls.GREASE_PLACEHOLDER), Data: []byte{0}},
+						{Group: tls.X25519MLKEM768},
+						{Group: tls.X25519},
+					}},
+					&tls.SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []tls.SignatureScheme{
+						// Chrome 152 sends a GREASE value as the first
+						// signature algorithm and picks a new one per connection.
+						randomGREASESignatureScheme(),
+						tls.SignatureScheme(0x0904),
+						tls.SignatureScheme(0x0905),
+						tls.SignatureScheme(0x0906),
+						tls.ECDSAWithP256AndSHA256,
+						tls.PSSWithSHA256,
+						tls.PKCS1WithSHA256,
+						tls.ECDSAWithP384AndSHA384,
+						tls.PSSWithSHA384,
+						tls.PKCS1WithSHA384,
+						tls.PSSWithSHA512,
+						tls.PKCS1WithSHA512,
+					}},
+					&tls.SupportedCurvesExtension{Curves: []tls.CurveID{
+						tls.GREASE_PLACEHOLDER,
+						tls.X25519MLKEM768,
+						tls.X25519,
+						tls.CurveP256,
+						tls.CurveP384,
+					}},
+					&tls.UtlsCompressCertExtension{Algorithms: []tls.CertCompressionAlgo{
+						tls.CertCompressionBrotli,
+					}},
+					&tls.ExtendedMasterSecretExtension{},
+					&tls.SessionTicketExtension{},
+					&tls.SNIExtension{},
+					&tls.RenegotiationInfoExtension{
+						Renegotiation: tls.RenegotiateOnceAsClient,
+					},
+					&tls.PSKKeyExchangeModesExtension{Modes: []uint8{
+						tls.PskModeDHE,
+					}},
+					&tls.SupportedPointsExtension{SupportedPoints: []byte{
+						tls.PointFormatUncompressed,
+					}},
+					&tls.StatusRequestExtension{},
+					&tls.ALPNExtension{AlpnProtocols: []string{
+						"h2",
+						"http/1.1",
+					}},
+					// server_padding (0x12e0, BoringSSL-internal, payload 4000) is
+					// Beta-only. Stable omits it. Uncomment to match Beta.
+					// &tls.GenericExtension{Id: 0x12e0, Data: []byte{0x0f, 0xa0}},
+					&tls.GenericExtension{Id: 0xca34, Data: chrome152TrustAnchors}, // https://source.chromium.org/search?q=TLSEXT_TYPE_trust_anchors https://issues.chromium.org/issues/398275713
+					&tls.UtlsGREASEExtension{},
+					&tls.UtlsPreSharedKeyExtension{},
+				},
+			}, nil
+		},
+	},
+	settings: map[http2.SettingID]uint32{
+		http2.SettingHeaderTableSize:   65536,
+		http2.SettingEnablePush:        0,
+		http2.SettingInitialWindowSize: 6291456,
+		http2.SettingMaxHeaderListSize: 262144,
+	},
+	settingsOrder: []http2.SettingID{
+		http2.SettingHeaderTableSize,
+		http2.SettingEnablePush,
+		http2.SettingInitialWindowSize,
+		http2.SettingMaxHeaderListSize,
+	},
+	pseudoHeaderOrder: []string{
+		":method",
+		":authority",
+		":scheme",
+		":path",
+	},
+	connectionFlow: 15663105,
+}
+
+var Chrome_152 = ClientProfile{
+	clientHelloId: tls.ClientHelloID{
+		Client:               "Chrome",
+		RandomExtensionOrder: false,
+		Version:              "152",
+		Seed:                 nil,
+		SpecFactory: func() (tls.ClientHelloSpec, error) {
+			return tls.ClientHelloSpec{
+				CipherSuites: []uint16{
+					tls.GREASE_PLACEHOLDER,
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+				},
+				CompressionMethods: []byte{
+					tls.CompressionNone,
+				},
+				Extensions: []tls.TLSExtension{
+					&tls.UtlsGREASEExtension{},
+					&tls.KeyShareExtension{KeyShares: []tls.KeyShare{
+						{Group: tls.CurveID(tls.GREASE_PLACEHOLDER), Data: []byte{0}},
+						{Group: tls.X25519MLKEM768},
+						{Group: tls.X25519},
+					}},
+					&tls.SNIExtension{},
+					&tls.ApplicationSettingsExtensionNew{
+						SupportedProtocols: []string{"h2"},
+					},
+					&tls.RenegotiationInfoExtension{
+						Renegotiation: tls.RenegotiateOnceAsClient,
+					},
+					&tls.SupportedCurvesExtension{Curves: []tls.CurveID{
+						tls.GREASE_PLACEHOLDER,
+						tls.X25519MLKEM768,
+						tls.X25519,
+						tls.CurveP256,
+						tls.CurveP384,
+					}},
+					&tls.UtlsCompressCertExtension{Algorithms: []tls.CertCompressionAlgo{
+						tls.CertCompressionBrotli,
+					}},
+					&tls.SessionTicketExtension{},
+					&tls.StatusRequestExtension{},
+					&tls.ExtendedMasterSecretExtension{},
+					&tls.SupportedVersionsExtension{Versions: []uint16{
+						tls.GREASE_PLACEHOLDER,
+						tls.VersionTLS13,
+						tls.VersionTLS12,
+					}},
+					&tls.SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []tls.SignatureScheme{
+						// Chrome 152 sends a GREASE value as the first
+						// signature algorithm and picks a new one per connection.
+						randomGREASESignatureScheme(),
+						tls.SignatureScheme(0x0904),
+						tls.SignatureScheme(0x0905),
+						tls.SignatureScheme(0x0906),
+						tls.ECDSAWithP256AndSHA256,
+						tls.PSSWithSHA256,
+						tls.PKCS1WithSHA256,
+						tls.ECDSAWithP384AndSHA384,
+						tls.PSSWithSHA384,
+						tls.PKCS1WithSHA384,
+						tls.PSSWithSHA512,
+						tls.PKCS1WithSHA512,
+					}},
+					&tls.SCTExtension{},
+					&tls.SupportedPointsExtension{SupportedPoints: []byte{
+						tls.PointFormatUncompressed,
+					}},
+					tls.BoringGREASEECH(),
+					&tls.ALPNExtension{AlpnProtocols: []string{
+						"h2",
+						"http/1.1",
+					}},
+					&tls.PSKKeyExchangeModesExtension{Modes: []uint8{
+						tls.PskModeDHE,
+					}},
+					// server_padding (0x12e0, BoringSSL-internal, payload 4000) is
+					// Beta-only. Stable omits it. Uncomment to match Beta.
+					// &tls.GenericExtension{Id: 0x12e0, Data: []byte{0x0f, 0xa0}},
+					&tls.GenericExtension{Id: 0xca34, Data: chrome152TrustAnchors}, // https://source.chromium.org/search?q=TLSEXT_TYPE_trust_anchors https://issues.chromium.org/issues/398275713
+					&tls.UtlsGREASEExtension{},
+				},
+			}, nil
+		},
+	},
+	settings: map[http2.SettingID]uint32{
+		http2.SettingHeaderTableSize:   65536,
+		http2.SettingEnablePush:        0,
+		http2.SettingInitialWindowSize: 6291456,
+		http2.SettingMaxHeaderListSize: 262144,
+	},
+	settingsOrder: []http2.SettingID{
+		http2.SettingHeaderTableSize,
+		http2.SettingEnablePush,
+		http2.SettingInitialWindowSize,
+		http2.SettingMaxHeaderListSize,
+	},
+	pseudoHeaderOrder: []string{
+		":method",
+		":authority",
+		":scheme",
+		":path",
+	},
+	connectionFlow: 15663105,
+}
+
 var Chrome_150_PSK = ClientProfile{
 	clientHelloId: tls.ClientHelloID{
 		Client:               "Chrome",

--- a/profiles/profiles.go
+++ b/profiles/profiles.go
@@ -34,6 +34,8 @@ var MappedTLSClients = map[string]ClientProfile{
 	"chrome_146_PSK":         Chrome_146_PSK,
 	"chrome_150":             Chrome_150,
 	"chrome_150_PSK":         Chrome_150_PSK,
+	"chrome_152":             Chrome_152,
+	"chrome_152_PSK":         Chrome_152_PSK,
 	"brave_146":              Brave_146,
 	"brave_146_PSK":          Brave_146_PSK,
 	"safari_15_6_1":          Safari_15_6_1,

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -18,6 +18,8 @@ func TestClients(t *testing.T) {
 	firefox_147(t)
 	t.Log("testing chrome 146 with PSK")
 	chrome_146_PSK(t)
+	t.Log("testing chrome 152 with PSK")
+	chrome_152_PSK(t)
 	t.Log("testing chrome 150 with PSK")
 	chrome_150_PSK(t)
 	t.Log("testing safari ios 26.0")
@@ -644,6 +646,47 @@ func chrome_146_PSK(t *testing.T) {
 	compareResponse(t, "chrome", clientFingerprints[chrome][profiles.Chrome_146_PSK.GetClientHelloStr()], resp)
 }
 
+func chrome_152_PSK(t *testing.T) {
+	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
+		tls_client.WithClientProfile(profiles.Chrome_152_PSK),
+		tls_client.WithTimeoutSeconds(120),
+	}
+
+	client, err := tls_client.NewHttpClient(nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, peetApiEndpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header = defaultHeader
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compareResponse(t, "chrome", clientFingerprints[chrome][profiles.Chrome_152.GetClientHelloStr()], resp)
+
+	req, err = http.NewRequest(http.MethodGet, peetApiEndpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header = defaultHeader
+
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compareResponse(t, "chrome", clientFingerprints[chrome][profiles.Chrome_152_PSK.GetClientHelloStr()], resp)
+}
+
 func chrome_150_PSK(t *testing.T) {
 	options := []tls_client.HttpClientOption{
 		skipPeetCertVerify,
@@ -1045,6 +1088,14 @@ func compareResponse(t *testing.T, clientName string, expectedValues map[string]
 		case ja3Hash:
 			if tlsApiResponse.TLS.Ja3Hash != expectedValue {
 				t.Errorf("TLS Ja3 hash mismatch.\nexpected: %s\nactual  : %s\nclient: %s", expectedValue, tlsApiResponse.TLS.Ja3Hash, clientName)
+			}
+		case ja4String:
+			if tlsApiResponse.TLS.Ja4R != expectedValue {
+				t.Errorf("TLS Ja4 mismatch.\nexpected: %s\nactual  : %s\nclient: %s", expectedValue, tlsApiResponse.TLS.Ja4R, clientName)
+			}
+		case ja4Hash:
+			if tlsApiResponse.TLS.Ja4 != expectedValue {
+				t.Errorf("TLS Ja4 hash mismatch.\nexpected: %s\nactual  : %s\nclient: %s", expectedValue, tlsApiResponse.TLS.Ja4, clientName)
 			}
 		case akamaiFingerprint:
 			if tlsApiResponse.HTTP2.AkamaiFingerprint != expectedValue {

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -148,6 +148,7 @@ var defaultOkHttp4Header = http.Header{
 
 func chrome116WithPsk(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_116_PSK),
 		tls_client.WithTimeoutSeconds(120),
 	}
@@ -188,6 +189,7 @@ func chrome116WithPsk(t *testing.T) {
 
 func chrome112(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_112),
 	}
 
@@ -213,6 +215,7 @@ func chrome112(t *testing.T) {
 
 func chrome111(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_111),
 	}
 
@@ -238,6 +241,7 @@ func chrome111(t *testing.T) {
 
 func chrome110(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_110),
 	}
 
@@ -263,6 +267,7 @@ func chrome110(t *testing.T) {
 
 func chrome109(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_109),
 	}
 
@@ -288,6 +293,7 @@ func chrome109(t *testing.T) {
 
 func chrome108(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_108),
 	}
 
@@ -313,6 +319,7 @@ func chrome108(t *testing.T) {
 
 func chrome107(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_107),
 	}
 
@@ -338,6 +345,7 @@ func chrome107(t *testing.T) {
 
 func chrome105(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_105),
 	}
 
@@ -363,6 +371,7 @@ func chrome105(t *testing.T) {
 
 func chrome104(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_104),
 	}
 
@@ -388,6 +397,7 @@ func chrome104(t *testing.T) {
 
 func chrome103(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_103),
 	}
 
@@ -413,6 +423,7 @@ func chrome103(t *testing.T) {
 
 func safari_16_0(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Safari_16_0),
 	}
 
@@ -438,6 +449,7 @@ func safari_16_0(t *testing.T) {
 
 func safari_iOS_16_0(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Safari_IOS_16_0),
 	}
 
@@ -463,6 +475,7 @@ func safari_iOS_16_0(t *testing.T) {
 
 func safari_iOS_18_0(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Safari_IOS_18_0),
 	}
 
@@ -488,6 +501,7 @@ func safari_iOS_18_0(t *testing.T) {
 
 func firefox_105(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Firefox_105),
 	}
 
@@ -513,6 +527,7 @@ func firefox_105(t *testing.T) {
 
 func firefox_106(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Firefox_106),
 	}
 
@@ -538,6 +553,7 @@ func firefox_106(t *testing.T) {
 
 func firefox_108(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Firefox_108),
 	}
 
@@ -563,6 +579,7 @@ func firefox_108(t *testing.T) {
 
 func chrome_124(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_124),
 	}
 
@@ -588,6 +605,7 @@ func chrome_124(t *testing.T) {
 
 func chrome_146_PSK(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_146_PSK),
 		tls_client.WithTimeoutSeconds(120),
 	}
@@ -628,6 +646,7 @@ func chrome_146_PSK(t *testing.T) {
 
 func chrome_150_PSK(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_150_PSK),
 		tls_client.WithTimeoutSeconds(120),
 	}
@@ -668,6 +687,7 @@ func chrome_150_PSK(t *testing.T) {
 
 func safari_iOS_26_0(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Safari_IOS_26_0),
 	}
 
@@ -693,6 +713,7 @@ func safari_iOS_26_0(t *testing.T) {
 
 func safari_iOS_18_5(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Safari_IOS_18_5),
 	}
 
@@ -718,6 +739,7 @@ func safari_iOS_18_5(t *testing.T) {
 
 func chrome_144(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_144),
 	}
 
@@ -743,6 +765,7 @@ func chrome_144(t *testing.T) {
 
 func chrome_133(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_133),
 	}
 
@@ -768,6 +791,7 @@ func chrome_133(t *testing.T) {
 
 func chrome_131(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_131),
 	}
 
@@ -793,6 +817,7 @@ func chrome_131(t *testing.T) {
 
 func chrome_120(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_120),
 	}
 
@@ -818,6 +843,7 @@ func chrome_120(t *testing.T) {
 
 func chrome_117(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_117),
 	}
 
@@ -843,6 +869,7 @@ func chrome_117(t *testing.T) {
 
 func firefox_147(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Firefox_147),
 	}
 
@@ -868,6 +895,7 @@ func firefox_147(t *testing.T) {
 
 func firefox_117(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Firefox_117),
 	}
 
@@ -893,6 +921,7 @@ func firefox_117(t *testing.T) {
 
 func firefox_110(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Firefox_110),
 	}
 
@@ -918,6 +947,7 @@ func firefox_110(t *testing.T) {
 
 func firefox_132(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Firefox_132),
 	}
 
@@ -943,6 +973,7 @@ func firefox_132(t *testing.T) {
 
 func opera_91(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Opera_91),
 	}
 
@@ -968,6 +999,7 @@ func opera_91(t *testing.T) {
 
 func safariIos17(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Safari_IOS_17_0),
 	}
 
@@ -1028,6 +1060,7 @@ func compareResponse(t *testing.T, clientName string, expectedValues map[string]
 
 func okhttp4Android13(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Okhttp4Android13),
 	}
 
@@ -1053,6 +1086,7 @@ func okhttp4Android13(t *testing.T) {
 
 func okhttp4Android12(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Okhttp4Android12),
 	}
 
@@ -1078,6 +1112,7 @@ func okhttp4Android12(t *testing.T) {
 
 func okhttp4Android11(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Okhttp4Android11),
 	}
 
@@ -1103,6 +1138,7 @@ func okhttp4Android11(t *testing.T) {
 
 func okhttp4Android10(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Okhttp4Android10),
 	}
 
@@ -1128,6 +1164,7 @@ func okhttp4Android10(t *testing.T) {
 
 func okhttp4Android9(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Okhttp4Android9),
 	}
 
@@ -1153,6 +1190,7 @@ func okhttp4Android9(t *testing.T) {
 
 func okhttp4Android8(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Okhttp4Android8),
 	}
 
@@ -1178,6 +1216,7 @@ func okhttp4Android8(t *testing.T) {
 
 func okhttp4Android7(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Okhttp4Android7),
 	}
 

--- a/tests/client_test_utils.go
+++ b/tests/client_test_utils.go
@@ -15,6 +15,8 @@ type TlsApiResponse struct {
 		TLSVersionNegotiated string   `json:"tls_version_negotiated"`
 		Ja3                  string   `json:"ja3"`
 		Ja3Hash              string   `json:"ja3_hash"`
+		Ja4                  string   `json:"ja4"`
+		Ja4R                 string   `json:"ja4_r"`
 		ClientRandom         string   `json:"client_random"`
 		SessionID            string   `json:"session_id"`
 		Ciphers              []string `json:"ciphers"`
@@ -77,6 +79,8 @@ const (
 
 	ja3String             = "ja3String"
 	ja3Hash               = "ja3Hash"
+	ja4String             = "ja4String"
+	ja4Hash               = "ja4Hash"
 	akamaiFingerprint     = "akamaiFingerprint"
 	akamaiFingerprintHash = "akamaiFingerprintHash"
 )
@@ -98,6 +102,22 @@ var clientFingerprints = map[string]map[string]map[string]string{
 		profiles.Chrome_146_PSK.GetClientHelloStr(): map[string]string{
 			ja3String:             "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,17613-43-18-65037-51-13-10-27-23-35-0-65281-45-11-5-16-51764-41,4588-29-23-24,0",
 			ja3Hash:               "b725019d0bcb612810eb226664682342",
+			akamaiFingerprint:     "1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p",
+			akamaiFingerprintHash: "52d84b11737d980aef856699f885ca86",
+		},
+		profiles.Chrome_152.GetClientHelloStr(): map[string]string{
+			ja3String:             "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,17613-43-18-65037-51-13-10-27-23-35-0-65281-45-11-5-16-51764,4588-29-23-24,0",
+			ja3Hash:               "5d510aa7220d1a7bc1256493e4b88909",
+			ja4String:             "t13d1517h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,ca34,fe0d,ff01_0904,0905,0906,0403,0804,0401,0503,0805,0501,0806,0601",
+			ja4Hash:               "t13d1517h2_8daaf6152771_cb7bf5808d99",
+			akamaiFingerprint:     "1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p",
+			akamaiFingerprintHash: "52d84b11737d980aef856699f885ca86",
+		},
+		profiles.Chrome_152_PSK.GetClientHelloStr(): map[string]string{
+			ja3String:             "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,17613-43-18-65037-51-13-10-27-23-35-0-65281-45-11-5-16-51764-41,4588-29-23-24,0",
+			ja3Hash:               "b725019d0bcb612810eb226664682342",
+			ja4String:             "t13d1518h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,0029,002b,002d,0033,44cd,ca34,fe0d,ff01_0904,0905,0906,0403,0804,0401,0503,0805,0501,0806,0601",
+			ja4Hash:               "t13d1518h2_8daaf6152771_e2d80978ab2e",
 			akamaiFingerprint:     "1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p",
 			akamaiFingerprintHash: "52d84b11737d980aef856699f885ca86",
 		},

--- a/tests/client_test_utils.go
+++ b/tests/client_test_utils.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	tls_client "github.com/bogdanfinn/tls-client"
 	"github.com/bogdanfinn/tls-client/profiles"
 	tls "github.com/bogdanfinn/utls"
 )
@@ -79,6 +80,12 @@ const (
 	akamaiFingerprint     = "akamaiFingerprint"
 	akamaiFingerprintHash = "akamaiFingerprintHash"
 )
+
+// skipPeetCertVerify disables certificate verification for one client.
+// tls.peet.ws serves a self-signed certificate, so verification fails there.
+// Only the tests that call peetApiEndpoint use this option.
+// Tests against other hosts keep normal certificate verification.
+var skipPeetCertVerify = tls_client.WithInsecureSkipVerify()
 
 var clientFingerprints = map[string]map[string]map[string]string{
 	chrome: {

--- a/tests/grease_signature_scheme_test.go
+++ b/tests/grease_signature_scheme_test.go
@@ -1,0 +1,69 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/bogdanfinn/tls-client/profiles"
+	tls "github.com/bogdanfinn/utls"
+)
+
+// greaseSignatureSchemeProfiles are the profiles that send a GREASE value as
+// their first signature algorithm. Add a row for a new browser version.
+var greaseSignatureSchemeProfiles = map[string]profiles.ClientProfile{
+	"Chrome_152":     profiles.Chrome_152,
+	"Chrome_152_PSK": profiles.Chrome_152_PSK,
+}
+
+// TestGreaseSignatureSchemeIsRandom builds ClientHello specs offline and checks
+// the first entry of signature_algorithms. Chrome sends a GREASE value there
+// and picks a new one for every connection.
+// TestGreaseSignatureAlgorithmOnTheWire checks the same value over the wire,
+// but it can only afford a handful of connections. This test draws enough
+// values to show that all 16 of them appear.
+func TestGreaseSignatureSchemeIsRandom(t *testing.T) {
+	for name, profile := range greaseSignatureSchemeProfiles {
+		t.Run(name, func(t *testing.T) {
+			greaseSignatureSchemeIsRandom(t, name, profile)
+		})
+	}
+}
+
+func greaseSignatureSchemeIsRandom(t *testing.T, name string, profile profiles.ClientProfile) {
+	t.Helper()
+
+	seen := map[uint64]int{}
+
+	for i := 0; i < 2000; i++ {
+		spec, err := profile.GetClientHelloSpec()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var schemes []tls.SignatureScheme
+
+		for _, extension := range spec.Extensions {
+			if signatureAlgorithms, ok := extension.(*tls.SignatureAlgorithmsExtension); ok {
+				schemes = signatureAlgorithms.SupportedSignatureAlgorithms
+				break
+			}
+		}
+
+		if len(schemes) == 0 {
+			t.Fatalf("%s sends no signature_algorithms extension", name)
+		}
+
+		value := uint64(schemes[0])
+
+		if !isGreaseValue(value) {
+			t.Fatalf("%s first signature algorithm is 0x%04x, expected a GREASE value", name, value)
+		}
+
+		seen[value]++
+	}
+
+	// There are 16 GREASE values. Over 2000 draws every one of them should
+	// appear, otherwise the value is not being randomized.
+	if len(seen) != 16 {
+		t.Errorf("%s used %d of the 16 GREASE values: %v", name, len(seen), seen)
+	}
+}

--- a/tests/header_order_test.go
+++ b/tests/header_order_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestClient_HeaderOrder(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_105),
 	}
 
@@ -102,6 +103,7 @@ func TestClient_HeaderOrder(t *testing.T) {
 
 func TestClient_HeaderOrderHttp1(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_105),
 		tls_client.WithForceHttp1(),
 	}
@@ -190,6 +192,7 @@ func TestClient_HeaderOrderHttp1(t *testing.T) {
 
 func TestClient_HeaderOrderWithContentLengthHttp1(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_105),
 		tls_client.WithForceHttp1(),
 	}
@@ -244,6 +247,7 @@ func TestClient_HeaderOrderWithContentLengthHttp1(t *testing.T) {
 
 func TestClient_HeaderOrderWithContentLength(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_105),
 	}
 

--- a/tests/random_extension_order_test.go
+++ b/tests/random_extension_order_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestClient_RandomExtensionOrderChrome(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.Chrome_107),
 		tls_client.WithRandomTLSExtensionOrder(),
 	}
@@ -65,6 +66,7 @@ func TestClient_RandomExtensionOrderChrome(t *testing.T) {
 
 func TestClient_RandomExtensionOrderCustom(t *testing.T) {
 	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
 		tls_client.WithClientProfile(profiles.CloudflareCustom),
 		tls_client.WithRandomTLSExtensionOrder(),
 	}

--- a/tests/signature_algorithms_test.go
+++ b/tests/signature_algorithms_test.go
@@ -1,0 +1,113 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+	tls_client "github.com/bogdanfinn/tls-client"
+)
+
+// isGreaseValue reports whether v is one of the 16 GREASE values defined in
+// RFC 8701: both bytes are equal and the low nibble is 0xa.
+func isGreaseValue(v uint64) bool {
+	return v>>8 == v&0xff && v&0xf == 0xa
+}
+
+// TestGreaseSignatureAlgorithmOnTheWire checks that the profile sends a GREASE
+// value as the first entry of the signature_algorithms extension, and that the
+// value changes between connections without moving the JA4 fingerprint. Chrome
+// 152 added that value. Neither JA3 nor JA4 covers the contents of
+// signature_algorithms, so the fingerprint assertions in client_test.go cannot
+// detect it.
+func TestGreaseSignatureAlgorithmOnTheWire(t *testing.T) {
+	ja4Values := map[string][]string{}
+
+	for name, profile := range greaseSignatureSchemeProfiles {
+		for run := 1; run <= 3; run++ {
+			t.Run(fmt.Sprintf("%s/run_%d", name, run), func(t *testing.T) {
+				options := []tls_client.HttpClientOption{
+					skipPeetCertVerify,
+					tls_client.WithClientProfile(profile),
+					tls_client.WithTimeoutSeconds(120),
+				}
+
+				client, err := tls_client.NewHttpClient(nil, options...)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				req, err := http.NewRequest(http.MethodGet, peetApiEndpoint, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				req.Header = defaultHeader
+
+				resp, err := client.Do(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				defer resp.Body.Close()
+
+				readBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				tlsApiResponse := TlsApiResponse{}
+				if err := json.Unmarshal(readBytes, &tlsApiResponse); err != nil {
+					t.Fatal(err)
+				}
+
+				var signatureAlgorithms []string
+
+				for _, extension := range tlsApiResponse.TLS.Extensions {
+					if strings.HasPrefix(extension.Name, "signature_algorithms (13)") {
+						signatureAlgorithms = extension.SignatureAlgorithms
+						break
+					}
+				}
+
+				if len(signatureAlgorithms) == 0 {
+					t.Fatalf("%s sent no signature_algorithms extension", name)
+				}
+
+				first := signatureAlgorithms[0]
+
+				value, err := strconv.ParseUint(strings.TrimPrefix(first, "0x"), 16, 16)
+				if err != nil {
+					t.Fatalf("%s first signature algorithm is %q, expected a GREASE value", name, first)
+				}
+
+				if !isGreaseValue(value) {
+					t.Errorf("%s first signature algorithm is %q, expected a GREASE value", name, first)
+				}
+
+				// JA4 ignores GREASE values, so the randomized signature algorithm
+				// must not move the JA4 fingerprint.
+				if tlsApiResponse.TLS.Ja4 == "" {
+					t.Fatalf("%s got no ja4 value from %s", name, peetApiEndpoint)
+				}
+
+				t.Logf("%s ja4: %s (first signature algorithm %s)", name, tlsApiResponse.TLS.Ja4, first)
+
+				ja4Values[name] = append(ja4Values[name], tlsApiResponse.TLS.Ja4)
+			})
+		}
+	}
+
+	for name, values := range ja4Values {
+		for _, value := range values {
+			if value != values[0] {
+				t.Errorf("%s ja4 changed between connections: %v", name, values)
+				break
+			}
+		}
+	}
+}

--- a/tests/trust_anchors_test.go
+++ b/tests/trust_anchors_test.go
@@ -1,0 +1,308 @@
+package tests
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+	tls_client "github.com/bogdanfinn/tls-client"
+	"github.com/bogdanfinn/tls-client/profiles"
+	tls "github.com/bogdanfinn/utls"
+)
+
+// trustAnchorsExtension is the code point of the trust_anchors extension.
+const trustAnchorsExtension = 0xca34
+
+// generate204Endpoint answers with 204 and an empty body. Google runs the TLS
+// trust anchor IDs draft, so it reads the extension instead of skipping it.
+const generate204Endpoint = "https://www.google.com/generate_204"
+
+// trustAnchorProfiles are the profiles that send the trust_anchors extension.
+// Add a row for a new browser version, together with its capture below.
+var trustAnchorProfiles = []struct {
+	name    string
+	profile profiles.ClientProfile
+	capture string
+}{
+	{"Chrome_152", profiles.Chrome_152, chrome152TrustAnchorsCapture},
+	{"Chrome_152_PSK", profiles.Chrome_152_PSK, chrome152TrustAnchorsCapture},
+}
+
+// chrome152TrustAnchorsCapture is the payload as stable Chrome 152.0.7977.64 on
+// Android sent it. The profile keeps its IDs and gives them a new order, so a
+// ClientHello that repeats this exact order means the reordering did not run.
+const chrome152TrustAnchorsCapture = "00b80582df13020108839a648c9b2d010c08839a648c9b2d010704d679090c08839a648c9b2d010a04d679090b08839a648c9b2d010d0582df13020e08839a648c9b2d010b04d67909050582df13020d0582df13021404d679090404d679090804d679090d04d679090a04d679090708839a648c9b2d011204d67909010582df13020608839a648c9b2d01080582df13021208839a648c9b2d011304d679090f0582df13021308839a648c9b2d01090582df13020f04d6790906"
+
+// splitTrustAnchors parses a RequestedTrustAnchorList the way a server does. It
+// returns the IDs in the order they arrived and fails the test on a malformed
+// payload.
+func splitTrustAnchors(t *testing.T, payload []byte) []string {
+	t.Helper()
+
+	if len(payload) < 2 {
+		t.Fatalf("payload of %d bytes is shorter than its length field", len(payload))
+	}
+
+	list := payload[2:]
+	if length := int(payload[0])<<8 | int(payload[1]); length != len(list) {
+		t.Fatalf("length field says %d bytes, list holds %d", length, len(list))
+	}
+
+	var ids []string
+
+	for i := 0; i < len(list); {
+		end := i + 1 + int(list[i])
+		if end > len(list) {
+			t.Fatalf("ID at offset %d runs past the end of the list", i)
+		}
+
+		ids = append(ids, hex.EncodeToString(list[i+1:end]))
+		i = end
+	}
+
+	return ids
+}
+
+// checkTrustAnchorIDs fails the test unless the payload holds the IDs of the
+// capture, each of them once and none of them missing. The order is free,
+// because Chromium writes the IDs in hash set iteration order.
+func checkTrustAnchorIDs(t *testing.T, name string, capture string, payload []byte) {
+	t.Helper()
+
+	want, err := hex.DecodeString(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := sortedTrustAnchorIDs(t, payload)
+	expected := sortedTrustAnchorIDs(t, want)
+
+	if len(got) != len(expected) {
+		t.Fatalf("%s sent %d trust anchor IDs, expected %d", name, len(got), len(expected))
+	}
+
+	for i, id := range got {
+		if id != expected[i] {
+			t.Errorf("%s sent %v, expected %v", name, got, expected)
+			return
+		}
+	}
+}
+
+// sortedTrustAnchorIDs parses a payload and returns its IDs in sorted order.
+func sortedTrustAnchorIDs(t *testing.T, payload []byte) []string {
+	t.Helper()
+
+	ids := splitTrustAnchors(t, payload)
+	sort.Strings(ids)
+
+	return ids
+}
+
+// trustAnchorsFromSpec returns the payload of the single trust_anchors
+// extension of the ClientHello.
+func trustAnchorsFromSpec(t *testing.T, profile profiles.ClientProfile) []byte {
+	t.Helper()
+
+	spec, err := profile.GetClientHelloSpec()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var payloads [][]byte
+
+	for _, extension := range spec.Extensions {
+		if generic, ok := extension.(*tls.GenericExtension); ok && generic.Id == trustAnchorsExtension {
+			payloads = append(payloads, generic.Data)
+		}
+	}
+
+	if len(payloads) != 1 {
+		t.Fatalf("%s sends %d trust_anchors extensions, expected 1", profile.GetClientHelloStr(), len(payloads))
+	}
+
+	return payloads[0]
+}
+
+// TestTrustAnchors checks the trust_anchors extension (0xca34). A profile holds
+// one captured payload and puts its IDs in a new order once per program run,
+// the way Chromium's hash set iteration order holds for the life of a process.
+// Neither JA3 nor JA4 covers the contents of an extension, so the fingerprint
+// assertions in client_test.go cannot detect a broken payload.
+func TestTrustAnchors(t *testing.T) {
+	for _, tc := range trustAnchorProfiles {
+		payloads := map[string]int{}
+
+		for run := 1; run <= 5; run++ {
+			t.Run(fmt.Sprintf("%s/run_%d", tc.name, run), func(t *testing.T) {
+				payload := trustAnchorsFromSpec(t, tc.profile)
+
+				checkTrustAnchorIDs(t, tc.name, tc.capture, payload)
+
+				payloads[hex.EncodeToString(payload)]++
+			})
+		}
+
+		// One program run keeps one order, so every ClientHello of this test
+		// must carry the same payload.
+		if len(payloads) != 1 {
+			t.Errorf("%s sent %d different payloads in one program run, expected 1", tc.name, len(payloads))
+		}
+
+		// The IDs have far more orders than a test can meet by chance, so a
+		// payload that repeats the capture means the reordering did not run.
+		if payloads[tc.capture] > 0 {
+			t.Errorf("%s repeats the captured order, so the IDs were not reordered", tc.name)
+		}
+	}
+}
+
+// TestTrustAnchorsOnTheWire checks what a server receives. It confirms that the
+// payload survives the handshake and that the JA4 fingerprint does not move
+// with it.
+func TestTrustAnchorsOnTheWire(t *testing.T) {
+	ja4Values := map[string][]string{}
+	payloads := map[string]int{}
+
+	for _, tc := range trustAnchorProfiles {
+		for run := 1; run <= 2; run++ {
+			t.Run(fmt.Sprintf("%s/run_%d", tc.name, run), func(t *testing.T) {
+				options := []tls_client.HttpClientOption{
+					skipPeetCertVerify,
+					tls_client.WithClientProfile(tc.profile),
+					tls_client.WithTimeoutSeconds(120),
+				}
+
+				client, err := tls_client.NewHttpClient(nil, options...)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				req, err := http.NewRequest(http.MethodGet, peetApiEndpoint, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				req.Header = defaultHeader
+
+				resp, err := client.Do(req)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				defer resp.Body.Close()
+
+				readBytes, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				tlsApiResponse := TlsApiResponse{}
+				if err := json.Unmarshal(readBytes, &tlsApiResponse); err != nil {
+					t.Fatal(err)
+				}
+
+				// tls.peet.ws reports the extension as "Unknown extension
+				// 51764" today and may name it once the draft lands, so match
+				// the code point in decimal and not the name around it.
+				data := ""
+				code := strconv.Itoa(trustAnchorsExtension)
+
+				for _, extension := range tlsApiResponse.TLS.Extensions {
+					if strings.Contains(extension.Name, code) {
+						data = extension.Data
+						break
+					}
+				}
+
+				if data == "" {
+					t.Fatalf("%s sent no trust_anchors extension", tc.name)
+				}
+
+				payload, err := hex.DecodeString(data)
+				if err != nil {
+					t.Fatalf("%s sent %q, which is not hex", tc.name, data)
+				}
+
+				checkTrustAnchorIDs(t, tc.name, tc.capture, payload)
+
+				// The wire payload must be the one the profile holds.
+				if want := hex.EncodeToString(trustAnchorsFromSpec(t, tc.profile)); data != want {
+					t.Errorf("%s sent %s, the profile holds %s", tc.name, data, want)
+				}
+
+				payloads[tc.name+" "+data]++
+
+				if tlsApiResponse.TLS.Ja4 == "" {
+					t.Fatalf("%s got no ja4 value from %s", tc.name, peetApiEndpoint)
+				}
+
+				ja4Values[tc.name] = append(ja4Values[tc.name], tlsApiResponse.TLS.Ja4)
+			})
+		}
+	}
+
+	if len(payloads) != len(trustAnchorProfiles) {
+		t.Errorf("one program run sent %d payloads, expected one per profile", len(payloads))
+	}
+
+	// JA4 counts extensions but not their contents, so the payload must not
+	// move the fingerprint.
+	for name, values := range ja4Values {
+		for _, value := range values {
+			if value != values[0] {
+				t.Errorf("%s ja4 changed between connections: %v", name, values)
+				break
+			}
+		}
+	}
+}
+
+// TestTrustAnchorsAreAcceptedByAServer sends the extension to a server that
+// reads it and checks that the handshake and the request go through.
+// Certificate verification stays on, so the whole handshake must hold.
+//
+// The test covers the shape of the payload, not the IDs in it. A server that
+// finds no ID it knows falls back to its normal certificate, so a list of
+// unknown IDs still answers with 204. The tests above cover the IDs.
+func TestTrustAnchorsAreAcceptedByAServer(t *testing.T) {
+	for _, tc := range trustAnchorProfiles {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := tls_client.NewHttpClient(nil,
+				tls_client.WithClientProfile(tc.profile),
+				tls_client.WithTimeoutSeconds(30),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req, err := http.NewRequest(http.MethodGet, generate204Endpoint, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req.Header = defaultHeader
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("%s could not reach %s: %s", tc.name, generate204Endpoint, err)
+			}
+
+			defer resp.Body.Close()
+
+			if _, err := io.ReadAll(resp.Body); err != nil {
+				t.Fatalf("%s could not read the body: %s", tc.name, err)
+			}
+
+			if resp.StatusCode != http.StatusNoContent {
+				t.Errorf("%s got status %d from %s, expected %d", tc.name, resp.StatusCode, generate204Endpoint, http.StatusNoContent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds `Chrome_152` and `Chrome_152_PSK`, cloned from the Chrome 150 pair, plus tests for the two extensions that JA3 and JA4 cannot see.

## ClientHello changes over Chrome 150

**A GREASE value as the first signature algorithm.** Chrome 152 sends one and redraws it per connection. utls does not substitute GREASE placeholders inside `signature_algorithms`, so `randomGREASESignatureScheme` draws the value in the `SpecFactory`. Its doc comment describes the upstream utls change that would let the profile write `tls.SignatureScheme(tls.GREASE_PLACEHOLDER)` like every other GREASE position, after which the helper can go away.

**`trust_anchors` (0xca34) restored.** Chrome 150 did not send the extension. Chrome 146 sent an empty list. Chrome 152 sends a real one.

**`server_padding` (0x12e0) left commented out.** Only the Beta channel sends it. Chrome 152 Stable does not. The line stays in the profile behind a comment for anyone who needs to match a Beta fingerprint.

## The trust_anchors payload

`profiles/extension_data.go` holds one hex capture from stable Chrome 152.0.7977.64 on Android: 186 bytes carrying 28 trust anchor IDs. That is the Chrome Root Store version 39 default with no MTC anchors, because `VerifyMTCs` is off by default. Captures from 152.0.7977.65 on Windows 11 and on Mac hold the same 28 IDs and differ only in order.

The order is not a stable value. Chromium keeps the IDs in an `absl::flat_hash_set` and writes them in iteration order, which holds for the life of a process and differs between processes. The profile therefore reorders the records once at package load, so one program run keeps one order and two runs differ. `mustSplitTrustAnchors` splits the capture into records and panics on a malformed literal, so a bad copy shows at package load rather than on the wire.

The file carries a four-step how-to for adding a capture for a later version: read the extension data from `tls.peet.ws/api/all`, add a const and a payload var, and pass the var to the profile.

## Fingerprints

Captured from `tls.peet.ws/api/all`.

| Profile | JA3 hash | JA4 |
| --- | --- | --- |
| `Chrome_152` | `5d510aa7220d1a7bc1256493e4b88909` | `t13d1517h2_8daaf6152771_cb7bf5808d99` |
| `Chrome_152_PSK` | `b725019d0bcb612810eb226664682342` | `t13d1518h2_8daaf6152771_e2d80978ab2e` |

The fingerprint map gained `ja4String` and `ja4Hash` next to `ja3String` and `ja3Hash`, so `ja4_r` and the hashed form are both compared.

## Tests

Neither JA3 nor JA4 reads the contents of an extension, so the fingerprint assertions cannot detect a broken payload. Four tests cover what they miss:

- `TestGreaseSignatureSchemeIsRandom` builds 2000 specs offline and checks that the first signature algorithm is always a GREASE value and that all 16 values appear.
- `TestGreaseSignatureAlgorithmOnTheWire` checks the same value over the wire and confirms that it does not move JA4.
- `TestTrustAnchors` checks that both profiles send one `trust_anchors` extension, that the payload holds the captured ID set, that one program run keeps one order, and that the order is not the captured one.
- `TestTrustAnchorsOnTheWire` confirms that the payload reaches the server unchanged and that JA4 stays put.
- `TestTrustAnchorsAreAcceptedByAServer` requests `https://www.google.com/generate_204` with certificate verification on and checks for 204. Google runs the trust anchor IDs draft, so the handshake must hold against a server that reads the extension. The test covers the shape of the payload and not the IDs in it: a server that knows none of the IDs falls back to its normal certificate, so a list of unknown IDs still answers with 204.

The profiles under test live in a table, so a Chrome 153 profile needs one row and no renaming. The wire tests match the extension by its code point, 51764, and not by the name `tls.peet.ws` prints for it.

`profiles/grease_test.go` moved to `tests/` and became black-box, which leaves the `profiles` package with no test files.

## Verification

- `go build ./...`
- `go test ./tests/ -run TestClients -count=1` passes for all 33 profiles.
- `go test ./tests/ -run 'TrustAnchors|Grease' -count=1` passes.
- The new tests were mutation checked: disabling the shuffle, moving it back to per-connection, dropping an ID, removing the extension, and pinning the GREASE value each make them fail.

## Note on #229

#229 reported that the `trust_anchors` extension was postponed and not delivered in Chrome 146. Chrome 152 does send it, so this pull request supersedes that one.
