### PR TITLE
Do not reuse a cached transport when ALPN changed on reconnect

### DIFF
--- a/roundtripper.go
+++ b/roundtripper.go
@@ -39,10 +39,22 @@ type roundTripper struct {
 	cachedConnections map[string]net.Conn
 	cachedTransports  map[string]http.RoundTripper
 
-	// cachedProtocols records the ALPN protocol each cached transport was built
-	// for, so a later handshake to the same address can tell whether the cached
-	// transport still fits what the server just negotiated.
-	cachedProtocols map[string]string
+	// cachedKinds records which kind of transport is cached for each address, so
+	// a later handshake to the same address can tell whether it still fits the
+	// protocol the server just negotiated.
+	//
+	// It holds the kind rather than the ALPN string because several protocols
+	// share one transport: a server that negotiates nothing and one that
+	// negotiates "http/1.1" both get the HTTP/1 transport, and comparing the raw
+	// strings would throw away a perfectly good transport when a load balancer
+	// omits ALPN on one connection.
+	//
+	// It has a mutex of its own rather than sharing cachedTransportsLck, because
+	// dialTLS runs both with that lock held, on the first dial through
+	// getTransport, and without it, on a reconnect from the transport's own
+	// dialer. Taking it here would deadlock the first of those.
+	cachedKinds    map[string]transportKind
+	cachedKindsLck sync.Mutex
 
 	headerPriority      *http2.PriorityParam
 	settings            map[http2.SettingID]uint32
@@ -86,6 +98,70 @@ type http3Config struct {
 	http3PriorityParam     uint32
 	http3PseudoHeaderOrder []string
 	http3SendGreaseFrames  bool
+}
+
+// transportKind is which of the three transports an ALPN result maps to.
+// Several protocols share one, which is why the kind rather than the protocol
+// string is what gets compared on a reconnect.
+type transportKind int
+
+const (
+	transportHTTP1 transportKind = iota
+	transportHTTP2
+	transportHTTP3
+)
+
+func kindForProtocol(protocol string) transportKind {
+	switch protocol {
+	case http2.NextProtoTLS:
+		return transportHTTP2
+	case http3.NextProtoH3:
+		return transportHTTP3
+	default:
+		return transportHTTP1
+	}
+}
+
+// errProtocolChanged is returned by dialTLS when the handshake negotiated a
+// protocol the cached transport for that address cannot speak.
+var errProtocolChanged = errors.New("tls-client: the server negotiated a protocol the cached transport does not speak")
+
+func (rt *roundTripper) cachedKind(addr string) (transportKind, bool) {
+	rt.cachedKindsLck.Lock()
+	defer rt.cachedKindsLck.Unlock()
+
+	kind, ok := rt.cachedKinds[addr]
+	return kind, ok
+}
+
+func (rt *roundTripper) setCachedKind(addr string, kind transportKind) {
+	rt.cachedKindsLck.Lock()
+	defer rt.cachedKindsLck.Unlock()
+
+	rt.cachedKinds[addr] = kind
+}
+
+// dropCachedTransport forgets the transport cached for addr.
+//
+// This lives here rather than in dialTLS because it writes cachedTransports,
+// and dialTLS runs without the lock that guards it whenever a cached transport
+// dials a replacement connection. It is only dropped when it is still the one
+// that failed, so a transport another goroutine has already replaced is left
+// alone.
+func (rt *roundTripper) dropCachedTransport(addr string, stale http.RoundTripper) {
+	rt.cachedTransportsLck.Lock()
+	if rt.cachedTransports[addr] == stale {
+		delete(rt.cachedTransports, addr)
+	}
+	rt.cachedTransportsLck.Unlock()
+
+	rt.cachedKindsLck.Lock()
+	delete(rt.cachedKinds, addr)
+	rt.cachedKindsLck.Unlock()
+
+	if closer, ok := stale.(interface{ CloseIdleConnections() }); ok {
+		closer.CloseIdleConnections()
+	}
 }
 
 func (rt *roundTripper) CloseIdleConnections() {
@@ -242,7 +318,12 @@ func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	t := rt.cachedTransports[addr]
 	rt.cachedTransportsLck.Unlock()
 
-	return t.RoundTrip(req)
+	resp, err := t.RoundTrip(req)
+	if err != nil && errors.Is(err, errProtocolChanged) {
+		rt.dropCachedTransport(addr, t)
+	}
+
+	return resp, err
 }
 
 func (rt *roundTripper) getTransport(req *http.Request, addr string) error {
@@ -326,45 +407,34 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 	}
 
 	negotiatedProtocol := conn.ConnectionState().NegotiatedProtocol
+	negotiatedKind := kindForProtocol(negotiatedProtocol)
 
 	// A transport is already cached for this address. Reuse it only when the
-	// handshake that just completed negotiated the same protocol it was built
-	// for.
+	// handshake that just completed negotiated a protocol it can speak.
 	//
 	// Servers do change their mind: an address behind a load balancer can offer
-	// http/1.1 on one connection and h2 on the next. Handing the new connection
-	// to the cached transport regardless means an HTTP/1 transport reading an
-	// HTTP/2 SETTINGS frame as if it were a status line, which fails with a
-	// "malformed HTTP response" naming the raw frame bytes, and keeps failing for
-	// that address until the whole client is thrown away.
+	// http/1.1 on one connection and h2 on the next. Handing the new connection to
+	// the cached transport regardless means an HTTP/1 transport reading an HTTP/2
+	// SETTINGS frame as if it were a status line, which fails with a "malformed
+	// HTTP response" naming the raw frame bytes and keeps failing for that address
+	// until the whole client is thrown away.
 	//
-	// The connection cannot be rescued here, because this dial belongs to the
-	// cached transport and that transport speaks the wrong protocol whatever we
-	// hand it. So drop the cache entry instead: this request fails with a message
-	// that says what happened, and the next one to the same address builds the
-	// transport the server is now asking for.
-	if cached := rt.cachedTransports[addr]; cached != nil {
-		cachedProtocol := rt.cachedProtocols[addr]
-		if cachedProtocol == negotiatedProtocol {
+	// This connection cannot be rescued, because the dial belongs to the transport
+	// that speaks the wrong protocol. Report it instead, and let RoundTrip drop the
+	// cache entry: it holds the lock that guards cachedTransports, and this
+	// function does not.
+	if cachedKind, ok := rt.cachedKind(addr); ok {
+		if cachedKind == negotiatedKind {
 			return conn, nil
 		}
 
-		if closer, ok := cached.(interface{ CloseIdleConnections() }); ok {
-			closer.CloseIdleConnections()
-		}
-		delete(rt.cachedTransports, addr)
-		delete(rt.cachedProtocols, addr)
 		_ = conn.Close()
 
-		return nil, fmt.Errorf(
-			"tls-client: %s negotiated %q but the cached transport speaks %q; that transport has been dropped, so the next request to this address builds one for the protocol the server is offering",
-			addr, negotiatedProtocol, cachedProtocol)
+		return nil, fmt.Errorf("%w: %s negotiated %q", errProtocolChanged, addr, negotiatedProtocol)
 	}
 
 	// No usable http.Transport for this address yet, create one based on the
 	// results of ALPN if no http1 is enforced.
-
-	rt.cachedProtocols[addr] = negotiatedProtocol
 
 	switch negotiatedProtocol {
 	case http2.NextProtoTLS:
@@ -449,6 +519,7 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 
 		t2.PushHandler = &http2.DefaultPushHandler{}
 		rt.cachedTransports[addr] = &t2
+		rt.setCachedKind(addr, transportHTTP2)
 	case http3.NextProtoH3:
 		t3, err := buildHTTP3Transport(&http3Config{
 			clientSessionCache:     rt.clientSessionCache,
@@ -465,8 +536,10 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 			return nil, err
 		}
 		rt.cachedTransports[addr] = t3
+		rt.setCachedKind(addr, transportHTTP3)
 	default:
 		rt.cachedTransports[addr] = rt.buildHttp1Transport()
+		rt.setCachedKind(addr, transportHTTP1)
 	}
 
 	// Stash the connection just established for use servicing the
@@ -622,7 +695,7 @@ func newRoundTripper(clientProfile profiles.ClientProfile, transportOptions *Tra
 		clientHelloId:               clientProfile.GetClientHelloId(),
 		cachedTransports:            make(map[string]http.RoundTripper),
 		cachedConnections:           make(map[string]net.Conn),
-		cachedProtocols:             make(map[string]string),
+		cachedKinds:                 make(map[string]transportKind),
 		disableIPV6:                 disableIPV6,
 		disableIPV4:                 disableIPV4,
 		bandwidthTracker:            bandwidthTracker,

--- a/roundtripper.go
+++ b/roundtripper.go
@@ -39,6 +39,11 @@ type roundTripper struct {
 	cachedConnections map[string]net.Conn
 	cachedTransports  map[string]http.RoundTripper
 
+	// cachedProtocols records the ALPN protocol each cached transport was built
+	// for, so a later handshake to the same address can tell whether the cached
+	// transport still fits what the server just negotiated.
+	cachedProtocols map[string]string
+
 	headerPriority      *http2.PriorityParam
 	settings            map[http2.SettingID]uint32
 	transportOptions    *TransportOptions
@@ -320,14 +325,48 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 		return nil, err
 	}
 
-	if rt.cachedTransports[addr] != nil {
-		return conn, nil
+	negotiatedProtocol := conn.ConnectionState().NegotiatedProtocol
+
+	// A transport is already cached for this address. Reuse it only when the
+	// handshake that just completed negotiated the same protocol it was built
+	// for.
+	//
+	// Servers do change their mind: an address behind a load balancer can offer
+	// http/1.1 on one connection and h2 on the next. Handing the new connection
+	// to the cached transport regardless means an HTTP/1 transport reading an
+	// HTTP/2 SETTINGS frame as if it were a status line, which fails with a
+	// "malformed HTTP response" naming the raw frame bytes, and keeps failing for
+	// that address until the whole client is thrown away.
+	//
+	// The connection cannot be rescued here, because this dial belongs to the
+	// cached transport and that transport speaks the wrong protocol whatever we
+	// hand it. So drop the cache entry instead: this request fails with a message
+	// that says what happened, and the next one to the same address builds the
+	// transport the server is now asking for.
+	if cached := rt.cachedTransports[addr]; cached != nil {
+		cachedProtocol := rt.cachedProtocols[addr]
+		if cachedProtocol == negotiatedProtocol {
+			return conn, nil
+		}
+
+		if closer, ok := cached.(interface{ CloseIdleConnections() }); ok {
+			closer.CloseIdleConnections()
+		}
+		delete(rt.cachedTransports, addr)
+		delete(rt.cachedProtocols, addr)
+		_ = conn.Close()
+
+		return nil, fmt.Errorf(
+			"tls-client: %s negotiated %q but the cached transport speaks %q; that transport has been dropped, so the next request to this address builds one for the protocol the server is offering",
+			addr, negotiatedProtocol, cachedProtocol)
 	}
 
-	// No http.Transport constructed yet, create one based on the results
-	// of ALPN if no http1 is enforced.
+	// No usable http.Transport for this address yet, create one based on the
+	// results of ALPN if no http1 is enforced.
 
-	switch conn.ConnectionState().NegotiatedProtocol {
+	rt.cachedProtocols[addr] = negotiatedProtocol
+
+	switch negotiatedProtocol {
 	case http2.NextProtoTLS:
 		utlsConfig := &tls.Config{ClientSessionCache: rt.clientSessionCache, InsecureSkipVerify: rt.insecureSkipVerify, OmitEmptyPsk: true}
 		if rt.transportOptions != nil {
@@ -583,6 +622,7 @@ func newRoundTripper(clientProfile profiles.ClientProfile, transportOptions *Tra
 		clientHelloId:               clientProfile.GetClientHelloId(),
 		cachedTransports:            make(map[string]http.RoundTripper),
 		cachedConnections:           make(map[string]net.Conn),
+		cachedProtocols:             make(map[string]string),
 		disableIPV6:                 disableIPV6,
 		disableIPV4:                 disableIPV4,
 		bandwidthTracker:            bandwidthTracker,

--- a/tests/alpn_change_test.go
+++ b/tests/alpn_change_test.go
@@ -1,0 +1,202 @@
+package tests
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	http "github.com/bogdanfinn/fhttp"
+	"github.com/bogdanfinn/fhttp/http2"
+	tls_client "github.com/bogdanfinn/tls-client"
+	"github.com/bogdanfinn/tls-client/profiles"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestClient_ProtocolChangeBetweenConnections covers a server that negotiates
+// http/1.1 on one connection and h2 on the next, which is ordinary behaviour
+// for an address behind a load balancer.
+//
+// The transport is cached per address. Before this was fixed, the cached
+// transport was reused on reconnect without checking the protocol that had just
+// been negotiated, so an HTTP/1 transport was handed an HTTP/2 connection and
+// read the SETTINGS frame as a status line:
+//
+//	malformed HTTP response "\x00\x00\x1e\x04\x00..."
+//
+// The address stayed broken until the whole client was replaced.
+//
+// The connection on which the change is discovered cannot be rescued, since
+// that dial belongs to the transport speaking the wrong protocol. So what this
+// checks is that the client RECOVERS: the request that runs into the change
+// fails with a message saying what happened, and the one after it succeeds over
+// the protocol the server is now offering. Without the fix the third request
+// fails exactly like the second, and so does every one after it.
+func TestClient_ProtocolChangeBetweenConnections(t *testing.T) {
+	var handshakes int64
+
+	cert := selfSignedCert(t)
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			config := &tls.Config{Certificates: []tls.Certificate{cert}}
+			if atomic.AddInt64(&handshakes, 1) == 1 {
+				config.NextProtos = []string{"http/1.1"}
+			} else {
+				config.NextProtos = []string{http2.NextProtoTLS}
+			}
+			return config, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go serveChangingProtocol(listener)
+
+	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(),
+		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithInsecureSkipVerify(),
+		tls_client.WithTimeoutSeconds(10),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	endpoint := fmt.Sprintf("https://%s/", listener.Addr().String())
+
+	// The first request negotiates http/1.1 and caches an HTTP/1 transport.
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "HTTP/1.1", resp.Proto)
+
+	// The server closed that connection, so the second request dials again and
+	// this time negotiates h2. The cached HTTP/1 transport cannot use it, so
+	// this request fails and the cache entry is dropped.
+	req2, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp2, err := client.Do(req2)
+	if err == nil {
+		resp2.Body.Close()
+		t.Fatal("expected the request that runs into the protocol change to fail")
+	}
+	assert.Contains(t, err.Error(), "cached transport speaks")
+
+	// The third request is the point of the fix. Without it this one, and every
+	// one after it, fails the same way as the second.
+	req3, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp3, err := client.Do(req3)
+	if err != nil {
+		t.Fatalf("third request, after the cached transport was dropped: %v", err)
+	}
+	defer resp3.Body.Close()
+
+	assert.Equal(t, 200, resp3.StatusCode)
+	assert.Equal(t, "HTTP/2.0", resp3.Proto)
+}
+
+// serveChangingProtocol answers each connection with whichever protocol its
+// handshake settled on, and closes an HTTP/1 connection after one response so
+// the client has to dial again.
+func serveChangingProtocol(listener net.Listener) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprint(w, "ok")
+	})
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+
+		go func(conn net.Conn) {
+			tlsConn, ok := conn.(*tls.Conn)
+			if !ok {
+				_ = conn.Close()
+				return
+			}
+			if err := tlsConn.Handshake(); err != nil {
+				_ = conn.Close()
+				return
+			}
+
+			if tlsConn.ConnectionState().NegotiatedProtocol == http2.NextProtoTLS {
+				(&http2.Server{}).ServeConn(conn, &http2.ServeConnOpts{Handler: handler})
+				return
+			}
+
+			server := &http.Server{Handler: handler}
+			_ = server.Serve(&singleConnListener{Conn: conn})
+		}(conn)
+	}
+}
+
+// singleConnListener hands one already accepted connection to an http.Server
+// and then reports that it is finished, so the server serves exactly that
+// connection and closes it.
+type singleConnListener struct {
+	net.Conn
+	used bool
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	if l.used {
+		return nil, fmt.Errorf("no more connections")
+	}
+	l.used = true
+	return l.Conn, nil
+}
+
+func (l *singleConnListener) Close() error   { return nil }
+func (l *singleConnListener) Addr() net.Addr { return l.Conn.LocalAddr() }
+
+func selfSignedCert(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}

--- a/tests/alpn_change_test.go
+++ b/tests/alpn_change_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -100,7 +101,7 @@ func TestClient_ProtocolChangeBetweenConnections(t *testing.T) {
 		resp2.Body.Close()
 		t.Fatal("expected the request that runs into the protocol change to fail")
 	}
-	assert.Contains(t, err.Error(), "cached transport speaks")
+	assert.Contains(t, err.Error(), "does not speak")
 
 	// The third request is the point of the fix. Without it this one, and every
 	// one after it, fails the same way as the second.
@@ -148,7 +149,12 @@ func serveChangingProtocol(listener net.Listener) {
 				return
 			}
 
+			// Keep-alive off, so the connection really is closed after the
+			// response and the client has to dial again. Without this the
+			// client may reuse it, no second handshake happens, and the test
+			// passes without exercising anything.
 			server := &http.Server{Handler: handler}
+			server.SetKeepAlivesEnabled(false)
 			_ = server.Serve(&singleConnListener{Conn: conn})
 		}(conn)
 	}
@@ -199,4 +205,126 @@ func selfSignedCert(t *testing.T) tls.Certificate {
 	}
 
 	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// TestClient_NoALPNThenHTTP1KeepsTheCachedTransport covers the other half of the
+// comparison. A load balancer that negotiates no ALPN on one connection and
+// "http/1.1" on the next has not changed anything: both get the HTTP/1
+// transport. Comparing the protocol strings rather than the transport they map
+// to would call that a change and throw away a working transport.
+func TestClient_NoALPNThenHTTP1KeepsTheCachedTransport(t *testing.T) {
+	var handshakes int64
+
+	cert := selfSignedCert(t)
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			config := &tls.Config{Certificates: []tls.Certificate{cert}}
+			if atomic.AddInt64(&handshakes, 1) > 1 {
+				config.NextProtos = []string{"http/1.1"}
+			}
+			return config, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go serveChangingProtocol(listener)
+
+	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(),
+		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithInsecureSkipVerify(),
+		tls_client.WithTimeoutSeconds(10),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	endpoint := fmt.Sprintf("https://%s/", listener.Addr().String())
+
+	for i := 1; i <= 2; i++ {
+		req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("request %d: %v, want no ALPN and http/1.1 to count as the same transport", i, err)
+		}
+
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Equal(t, "HTTP/1.1", resp.Proto)
+		resp.Body.Close()
+	}
+
+	assert.Greater(t, atomic.LoadInt64(&handshakes), int64(1), "the second request should have dialed again")
+}
+
+// TestClient_ProtocolChangeUnderConcurrentLoad drives the same protocol change
+// with requests in flight, which is where dropping the cached transport can race
+// with RoundTrip reading it. Run with -race.
+func TestClient_ProtocolChangeUnderConcurrentLoad(t *testing.T) {
+	var handshakes int64
+
+	cert := selfSignedCert(t)
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			config := &tls.Config{Certificates: []tls.Certificate{cert}}
+			if atomic.AddInt64(&handshakes, 1) == 1 {
+				config.NextProtos = []string{"http/1.1"}
+			} else {
+				config.NextProtos = []string{http2.NextProtoTLS}
+			}
+			return config, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go serveChangingProtocol(listener)
+
+	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(),
+		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithInsecureSkipVerify(),
+		tls_client.WithTimeoutSeconds(10),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	endpoint := fmt.Sprintf("https://%s/", listener.Addr().String())
+
+	// One request first, so an HTTP/1 transport is cached and every goroutine
+	// below runs into the change rather than racing to build the first one.
+	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp, err := client.Do(req); err == nil {
+		resp.Body.Close()
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 24; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+			if err != nil {
+				return
+			}
+			// Whether an individual request succeeds is not the point. Some run
+			// into the change and some do not. The point is that none of this
+			// panics on a concurrent map write.
+			if resp, err := client.Do(req); err == nil {
+				resp.Body.Close()
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes the problem reported in #263.

## What happens

`dialTLS` returns a freshly handshaked connection to the transport cached for
that address without checking which protocol the handshake just negotiated:

```go
if rt.cachedTransports[addr] != nil {
	return conn, nil
}

// No http.Transport constructed yet, create one based on the results
// of ALPN if no http1 is enforced.
switch conn.ConnectionState().NegotiatedProtocol {
```

ALPN is only consulted when there is no transport yet. An address behind a load
balancer can offer `http/1.1` on one connection and `h2` on the next, and the
cached HTTP/1 transport then reads the HTTP/2 SETTINGS frame as a status line:

```
net/http: HTTP/1.x transport connection broken: malformed HTTP response "\x00\x00\x1e\x04\x00..."
```

It keeps failing for that address for the life of the client.

I reproduced it independently against current master (b790a31) with a local TLS
listener that offers `http/1.1` on the first handshake and `h2` afterwards. Both
ends agree: the server logs `bogus greeting "GET / HTTP/1.1\r\nHost: 12"`.

## What this changes

`cachedProtocols` records the protocol each cached transport was built for. When
a later handshake negotiates something else, the cache entry is dropped instead
of being handed a connection it cannot read.

The connection this is discovered on cannot be rescued, because that dial
belongs to the transport speaking the wrong protocol, so whatever it is handed
is wrong. The request therefore still fails, but with a message saying what
happened, and the next request to the address builds a transport for the
protocol on offer. That is the part that matters: today the address stays broken
until the whole client is replaced.

## Test

`tests/alpn_change_test.go` walks the sequence:

| | on master | with this change |
|---|---|---|
| request 1, server offers http/1.1 | 200 HTTP/1.1 | 200 HTTP/1.1 |
| request 2, server switches to h2 | `malformed HTTP response "\x00\x00..."` | fails, naming the protocol change |
| request 3 | same failure, and every one after it | **200 HTTP/2.0** |

It fails on a clean master checkout with only the test file added, and passes
with the change. No network, it uses a local listener and a self-signed
certificate.

## Scope

Two things I deliberately left out, happy to add either if you would rather have
them here:

- **Retrying inside `RoundTrip`** so the request that runs into the change
  succeeds rather than failing once. That is the nicer behaviour, but it touches
  retry semantics and replayable request bodies, which felt like your call
  rather than something to slip into a bug fix.
- **Locking.** `cachedTransports` is written under `cachedTransportsLck` in
  `RoundTrip` and under the embedded mutex in `dialTLS`. I left that as it is and
  write `cachedProtocols` under the same lock as the map beside it, so this
  change does not alter the locking either way.
