### PR TITLE
Do not write the transport cache from a reconnecting dial

### DIFF
--- a/roundtripper.go
+++ b/roundtripper.go
@@ -355,7 +355,7 @@ func (rt *roundTripper) getTransport(req *http.Request, addr string) error {
 		return fmt.Errorf("invalid URL scheme: [%v]", req.URL.Scheme)
 	}
 
-	_, err := rt.dialTLS(req.Context(), "tcp", addr)
+	_, err := rt.dialTLSSetup(req.Context(), "tcp", addr)
 	switch err {
 	case errProtocolNegotiated:
 	case nil:
@@ -368,7 +368,28 @@ func (rt *roundTripper) getTransport(req *http.Request, addr string) error {
 	return nil
 }
 
+// dialTLS is the transport's own DialTLSContext, so it runs whenever a cached
+// transport opens a replacement connection. RoundTrip has released
+// cachedTransportsLck by then, so this path must not write cachedTransports.
 func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.Conn, error) {
+	return rt.dialTLSWithSetup(ctx, network, addr, false)
+}
+
+// dialTLSSetup is the first dial for an address, made by getTransport while the
+// caller holds cachedTransportsLck. It is the only path allowed to put a
+// transport in the cache.
+func (rt *roundTripper) dialTLSSetup(ctx context.Context, network, addr string) (net.Conn, error) {
+	return rt.dialTLSWithSetup(ctx, network, addr, true)
+}
+
+// dialTLSWithSetup does the dial and the handshake for both.
+//
+// setup says whether the caller holds cachedTransportsLck, and so whether this
+// may build a transport and cache it. Every other caller reaches here from
+// inside a transport's own RoundTrip, on a goroutine of the transport's making,
+// with no lock held at all: writing the map there raced with the read in
+// RoundTrip, on two different mutexes.
+func (rt *roundTripper) dialTLSWithSetup(ctx context.Context, network, addr string, setup bool) (net.Conn, error) {
 	rt.Lock()
 	defer rt.Unlock()
 
@@ -428,8 +449,9 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 	negotiatedProtocol := conn.ConnectionState().NegotiatedProtocol
 	negotiatedKind := kindForProtocol(negotiatedProtocol)
 
-	// A transport is already cached for this address. Reuse it only when the
-	// handshake that just completed negotiated a protocol it can speak.
+	// A reconnect belongs to a transport that already exists, so it never builds
+	// one: it either hands the connection back or reports that the connection is
+	// unusable.
 	//
 	// Servers do change their mind: an address behind a load balancer can offer
 	// http/1.1 on one connection and h2 on the next. Handing the new connection to
@@ -438,20 +460,33 @@ func (rt *roundTripper) dialTLS(ctx context.Context, network, addr string) (net.
 	// HTTP response" naming the raw frame bytes and keeps failing for that address
 	// until the whole client is thrown away.
 	//
-	// This connection cannot be rescued, because the dial belongs to the transport
-	// that speaks the wrong protocol. Report it instead, and let RoundTrip drop the
-	// cache entry: it holds the lock that guards cachedTransports, and this
-	// function does not.
-	if cachedKind, ok := rt.cachedKind(addr); ok {
-		if cachedKind == negotiatedKind {
+	// Neither case can be rescued here, because the dial belongs to the transport
+	// that speaks the wrong protocol and this function does not hold the lock that
+	// guards cachedTransports. Report it and let RoundTrip drop the entry and
+	// rebuild through getTransport.
+	if !setup {
+		cachedKind, ok := rt.cachedKind(addr)
+		switch {
+		case ok && cachedKind == negotiatedKind:
 			return conn, nil
+		case ok:
+			_ = conn.Close()
+
+			return nil, fmt.Errorf("%w: %s negotiated %q", errProtocolChanged, addr, negotiatedProtocol)
+		default:
+			// The entry was dropped while this transport was still in flight.
+			_ = conn.Close()
+
+			return nil, fmt.Errorf("%w: %s negotiated %q with no transport cached", errProtocolChanged, addr, negotiatedProtocol)
 		}
-
-		_ = conn.Close()
-
-		return nil, fmt.Errorf("%w: %s negotiated %q", errProtocolChanged, addr, negotiatedProtocol)
 	}
 
+	// The setup dial always builds, and deliberately does not consult
+	// cachedKinds. getTransport only calls it when no transport is cached, so
+	// there is nothing to reuse, and a kind left behind by a drop that has not
+	// finished would otherwise return the connection with a nil error, which
+	// getTransport panics on.
+	//
 	// No usable http.Transport for this address yet, create one based on the
 	// results of ALPN if no http1 is enforced.
 

--- a/roundtripper_setup_test.go
+++ b/roundtripper_setup_test.go
@@ -1,0 +1,128 @@
+package tls_client
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	http "github.com/bogdanfinn/fhttp"
+	"github.com/bogdanfinn/fhttp/http2"
+	"github.com/bogdanfinn/tls-client/bandwidth"
+	"github.com/bogdanfinn/tls-client/profiles"
+	"golang.org/x/net/proxy"
+)
+
+// TestGetTransportDoesNotPanicWhenOnlyTheKindSurvivedADrop covers the window
+// inside dropCachedTransport.
+//
+// It takes cachedTransportsLck to delete the transport and cachedKindsLck to
+// delete the kind, one after the other, so in between an address has a kind and
+// no transport. A RoundTrip landing there finds nothing cached, calls
+// getTransport, and the setup dial used to see the surviving kind, decide the
+// connection was reusable and return it with a nil error. getTransport panics
+// on exactly that.
+//
+// The state is set up directly rather than raced into, because a window between
+// two mutex releases is not something a test can hit on purpose.
+func TestGetTransportDoesNotPanicWhenOnlyTheKindSurvivedADrop(t *testing.T) {
+	cert := testCert(t)
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{http2.NextProtoTLS},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				if tlsConn, ok := c.(*tls.Conn); ok {
+					_ = tlsConn.Handshake()
+				}
+			}(conn)
+		}
+	}()
+
+	addr := listener.Addr().String()
+
+	tripper, err := newRoundTripper(profiles.Chrome_133, nil, "", true, false, false, true, false, false,
+		nil, nil, false, false, bandwidth.NewNopeTracker(), "", proxy.Direct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rt := tripper.(*roundTripper)
+
+	// The state the drop leaves behind for a moment: a kind, and no transport.
+	rt.setCachedKind(addr, transportHTTP2)
+
+	req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Control: the state really is the one described, or the call below proves
+	// nothing about it.
+	if _, ok := rt.cachedKind(addr); !ok {
+		t.Fatal("no cached kind, so this does not exercise the window")
+	}
+	rt.cachedTransportsLck.Lock()
+	_, cached := rt.cachedTransports[addr]
+	rt.cachedTransportsLck.Unlock()
+	if cached {
+		t.Fatal("a transport is already cached, so getTransport would not be called")
+	}
+
+	rt.cachedTransportsLck.Lock()
+	defer rt.cachedTransportsLck.Unlock()
+
+	// A panic here is the failure. An error is fine: the point is that the setup
+	// dial does not report success without caching a transport.
+	if err := rt.getTransport(req, addr); err != nil {
+		t.Fatalf("getTransport: %v", err)
+	}
+
+	if _, ok := rt.cachedTransports[addr]; !ok {
+		t.Error("getTransport returned without caching a transport")
+	}
+}
+
+func testCert(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}

--- a/tests/cached_transports_race_test.go
+++ b/tests/cached_transports_race_test.go
@@ -1,0 +1,89 @@
+package tests
+
+import (
+	"crypto/tls"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+	"github.com/bogdanfinn/fhttp/http2"
+	tls_client "github.com/bogdanfinn/tls-client"
+	"github.com/bogdanfinn/tls-client/profiles"
+)
+
+// TestClient_ConcurrentReconnectsDoNotRaceOnCachedTransports drives the map
+// from both sides at once.
+//
+// cachedTransports is written in two places under two different mutexes.
+// RoundTrip reads and writes it under cachedTransportsLck, while dialTLS writes
+// it under the roundTripper's own embedded mutex. That is safe only while every
+// dialTLS call happens with cachedTransportsLck held, which is true of the
+// first dial, since it goes through getTransport, and false of every reconnect:
+// dialTLS is the transport's own DialTLSContext, so it runs from inside
+// t.RoundTrip, after RoundTrip has released the lock.
+//
+// A server that negotiates a different protocol on every handshake makes those
+// reconnects happen constantly, so a few goroutines are enough to put a write
+// from one and a read from another in the same window.
+func TestClient_ConcurrentReconnectsDoNotRaceOnCachedTransports(t *testing.T) {
+	var handshakes int64
+
+	cert := selfSignedCert(t)
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		GetConfigForClient: func(*tls.ClientHelloInfo) (*tls.Config, error) {
+			config := &tls.Config{Certificates: []tls.Certificate{cert}}
+			// Alternate on every handshake rather than once, so the cached
+			// transport is wrong again as soon as it has been rebuilt.
+			if atomic.AddInt64(&handshakes, 1)%2 == 1 {
+				config.NextProtos = []string{"http/1.1"}
+			} else {
+				config.NextProtos = []string{http2.NextProtoTLS}
+			}
+			return config, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go serveChangingProtocol(listener)
+
+	client, err := tls_client.NewHttpClient(tls_client.NewNoopLogger(),
+		tls_client.WithClientProfile(profiles.Chrome_133),
+		tls_client.WithInsecureSkipVerify(),
+		tls_client.WithTimeoutSeconds(30),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	endpoint := fmt.Sprintf("https://%s/", listener.Addr().String())
+
+	// The errors are not the point and are deliberately ignored: half of these
+	// requests are expected to meet a protocol that has moved. The point is
+	// what the race detector sees while they overlap.
+	const goroutines, requests = 60, 8
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < requests; j++ {
+				req, err := http.NewRequest(http.MethodGet, endpoint, nil)
+				if err != nil {
+					return
+				}
+				resp, err := client.Do(req)
+				if err == nil {
+					resp.Body.Close()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Follow-up to #266. I found this one while chasing that race and reported it in
the thread instead of folding a locking change into a bug fix.

## The race

`cachedTransports` is guarded by `cachedTransportsLck`, and `dialTLS` writes it
holding only the roundTripper's own embedded mutex. Two mutexes, one map.

The first dial for an address is fine: it goes through `getTransport`, and
`RoundTrip` holds `cachedTransportsLck` around that. A reconnect is not.
`dialTLS` is the transport's own `DialTLSContext`, so it runs from inside
`t.RoundTrip`, on a goroutine the transport created, after `RoundTrip` has let
the lock go.

The window opens when an entry is dropped while a transport is still in flight.
`dropCachedTransport` removes the recorded kind, so that transport's next dial
finds no kind, falls past the reuse check, and lands in the branch that builds
and stores a transport.

On current master, under `go test -race`:

```
WARNING: DATA RACE
Write at 0x00c0001f7a70 by goroutine 139:
  tls-client.(*roundTripper).dialTLS()          roundtripper.go:561
  fhttp.(*Transport).customDialTLS()            transport.go:1314
  fhttp.(*Transport).dialConn()                 transport.go:1580

Previous read at 0x00c0001f7a70 by goroutine 31:
  tls-client.(*roundTripper).RoundTrip()        roundtripper.go:325
```

The write side is a plain `dialConn`, so protocol racing does not need to be on.
Any client meeting a server that changes its negotiated protocol can hit it.

## The fix

`dialTLS` cannot just take `cachedTransportsLck`. It runs with that lock held on
the first dial and without it on a reconnect, so taking it there deadlocks the
first path.

Instead the write leaves the reconnect path. The dial now knows which of the two
it is, and only the setup dial builds and caches. A reconnect either hands the
connection back, when the cached kind still matches what was negotiated, or
closes it and returns `errProtocolChanged`. `RoundTrip` already handles that by
dropping the entry and rebuilding through `getTransport`, under the lock, which
is what a changed protocol does today.

## A second bug, from the review

The setup dial no longer consults `cachedKinds` either.

`dropCachedTransport` clears `cachedTransports` under one lock and `cachedKinds`
under another, one after the other, so for a moment an address has a kind and no
transport. A `RoundTrip` landing there finds nothing cached and calls
`getTransport`, and the setup dial would see the surviving kind, treat the
connection as reusable and return it with a nil error. `getTransport` panics on
that:

```
panic: dialTLS returned no error when determining cachedTransports
```

Reachable on master. `getTransport` only runs when no transport is cached, so
there is nothing to reuse and the setup dial should always build.

## Tests

`TestClient_ConcurrentReconnectsDoNotRaceOnCachedTransports` puts 60 goroutines
through a server that alternates ALPN on every handshake, so reconnects and
cached reads overlap constantly. Exit 1 on unmodified master, passes with the
change. It ignores request errors, since half of them are expected to meet a
protocol that has moved and what matters is what the race detector sees.

`TestGetTransportDoesNotPanicWhenOnlyTheKindSurvivedADrop` covers the panic. It
sets the half-dropped state up directly, since a window between two mutex
releases is not something a test can hit reliably, and it checks that state
before making the call. Restoring the old behaviour makes it panic.

`TestClient_ProtocolChangeBetweenConnections`,
`TestClient_ProtocolChangeUnderConcurrentLoad`,
`TestClient_ProtocolChangeWithRacingRecovers` and
`TestClient_NoALPNThenHTTP1KeepsTheCachedTransport` still pass under `-race`.
