### PR TITLE
Default headers for the Chrome and Brave profiles

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -132,6 +132,19 @@ func main() {
 }
 ```
 
+### The browser's headers for a profile
+
+A request with no headers goes out as `Go-http-client`, whatever profile the client has. `DefaultHeaders` gives the headers the profile's browser sends on a navigation, in the browser's order, for the Chrome and Brave profiles:
+
+```go
+headers, ok := profiles.Chrome_152.DefaultHeaders()
+if ok {
+	options = append(options, tls_client.WithDefaultHeaders(headers))
+}
+```
+
+They apply to requests that set no headers of their own. The set is what the browser sends over HTTP/2; over HTTP/1.1 the browser sends no `priority` header, so with `WithForceHttp1` do `delete(headers, "priority")` first. Through the shared library the same set is used when a request names a browser profile and carries neither `headers` nor `defaultHeaders`.
+
 ### Questions?
 
 Join my discord support server for free: https://discord.gg/7Ej9eJvHqk

--- a/cffi_src/build_request_test.go
+++ b/cffi_src/build_request_test.go
@@ -19,6 +19,16 @@ func TestBuildRequestWithoutHeadersLeavesTheMapEmpty(t *testing.T) {
 		t.Fatalf("an input without headers gives a request with %d header entries: %v", len(req.Header), req.Header)
 	}
 
+	// An order with nothing to order is the same case: the default headers
+	// bring their own.
+	req, cerr = BuildRequest(RequestInput{RequestMethod: "GET", RequestUrl: "https://example.test/", HeaderOrder: []string{"user-agent", "accept"}})
+	if cerr != nil {
+		t.Fatal(cerr)
+	}
+	if len(req.Header) != 0 {
+		t.Fatalf("an order without headers gives a request with %d header entries: %v", len(req.Header), req.Header)
+	}
+
 	// The control: an order that was given is kept.
 	req, cerr = BuildRequest(RequestInput{
 		RequestMethod: "GET", RequestUrl: "https://example.test/",

--- a/cffi_src/build_request_test.go
+++ b/cffi_src/build_request_test.go
@@ -1,0 +1,33 @@
+package tls_client_cffi_src
+
+import (
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+)
+
+// The client's default headers stand in for an empty header set, so a request
+// built from an input with no headers has to have an empty header map. It used
+// to carry the header order key with nothing in it, and that one entry was
+// enough to keep defaultHeaders from ever applying through the shared library.
+func TestBuildRequestWithoutHeadersLeavesTheMapEmpty(t *testing.T) {
+	req, cerr := BuildRequest(RequestInput{RequestMethod: "GET", RequestUrl: "https://example.test/"})
+	if cerr != nil {
+		t.Fatal(cerr)
+	}
+	if len(req.Header) != 0 {
+		t.Fatalf("an input without headers gives a request with %d header entries: %v", len(req.Header), req.Header)
+	}
+
+	// The control: an order that was given is kept.
+	req, cerr = BuildRequest(RequestInput{
+		RequestMethod: "GET", RequestUrl: "https://example.test/",
+		Headers: map[string]string{"a": "1", "b": "2"}, HeaderOrder: []string{"b", "a"},
+	})
+	if cerr != nil {
+		t.Fatal(cerr)
+	}
+	if got := req.Header[http.HeaderOrderKey]; len(got) != 2 || got[0] != "b" {
+		t.Errorf("the header order was not kept: %v", got)
+	}
+}

--- a/cffi_src/default_headers_test.go
+++ b/cffi_src/default_headers_test.go
@@ -3,6 +3,7 @@ package tls_client_cffi_src
 import (
 	"strings"
 	"testing"
+	"time"
 
 	http "github.com/bogdanfinn/fhttp"
 	"github.com/bogdanfinn/fhttp/httptest"
@@ -12,9 +13,11 @@ import (
 // browser's headers; a request with a header of its own, or with a profile that
 // is not a mapped browser, is left as it was.
 func TestABrowserProfileWithNoHeadersSendsTheBrowsersHeaders(t *testing.T) {
-	var got http.Header
+	// The handler runs on the server's goroutine, so what it saw travels
+	// over a channel instead of a shared variable.
+	got := make(chan http.Header, 1)
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		got = r.Header.Clone()
+		got <- r.Header.Clone()
 	}))
 	defer srv.Close()
 
@@ -38,7 +41,13 @@ func TestABrowserProfileWithNoHeadersSendsTheBrowsersHeaders(t *testing.T) {
 			t.Fatal(err)
 		}
 		resp.Body.Close()
-		return got
+		select {
+		case h := <-got:
+			return h
+		case <-time.After(5 * time.Second):
+			t.Fatal("the server saw no request")
+			return nil
+		}
 	}
 
 	h := send(t, RequestInput{TLSClientIdentifier: "chrome_152"})

--- a/cffi_src/default_headers_test.go
+++ b/cffi_src/default_headers_test.go
@@ -1,0 +1,64 @@
+package tls_client_cffi_src
+
+import (
+	"strings"
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+	"github.com/bogdanfinn/fhttp/httptest"
+)
+
+// A request that names a browser profile and sets no headers goes out with the
+// browser's headers; a request with a header of its own, or with a profile that
+// is not a mapped browser, is left as it was.
+func TestABrowserProfileWithNoHeadersSendsTheBrowsersHeaders(t *testing.T) {
+	var got http.Header
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+	}))
+	defer srv.Close()
+
+	send := func(t *testing.T, input RequestInput) http.Header {
+		t.Helper()
+		input.RequestMethod = "GET"
+		input.RequestUrl = srv.URL
+		input.InsecureSkipVerify = true
+		input.WithoutCookieJar = true
+		input.TimeoutSeconds = 10
+		client, _, _, cerr := CreateClient(input)
+		if cerr != nil {
+			t.Fatal(cerr)
+		}
+		req, cerr := BuildRequest(input)
+		if cerr != nil {
+			t.Fatal(cerr)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		return got
+	}
+
+	h := send(t, RequestInput{TLSClientIdentifier: "chrome_152"})
+	if ua := h.Get("User-Agent"); !strings.Contains(ua, "Chrome/152.0.0.0") {
+		t.Errorf("chrome_152 with no headers sent User-Agent %q", ua)
+	}
+	if h.Get("sec-ch-ua") == "" || h.Get("Accept-Language") == "" {
+		t.Errorf("chrome_152 with no headers sent an incomplete set: %v", h)
+	}
+
+	h = send(t, RequestInput{TLSClientIdentifier: "chrome_152", Headers: map[string]string{"user-agent": "mine"}})
+	if ua := h.Get("User-Agent"); ua != "mine" {
+		t.Errorf("a request with its own User-Agent sent %q", ua)
+	}
+	if h.Get("sec-ch-ua") != "" {
+		t.Errorf("a request with its own headers had the browser's added: %v", h)
+	}
+
+	h = send(t, RequestInput{TLSClientIdentifier: "firefox_133"})
+	if ua := h.Get("User-Agent"); strings.Contains(ua, "Chrome") {
+		t.Errorf("firefox_133 has no mapped headers and still sent %q", ua)
+	}
+}

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -142,10 +142,10 @@ func BuildRequest(input RequestInput) (*http.Request, *TLSClientError) {
 		headers[key] = []string{value}
 	}
 
-	// Only when an order was given. An empty order still counts as a header,
-	// and the client's default headers apply to an empty set only, so putting
-	// it here unconditionally kept them from ever applying.
-	if len(input.HeaderOrder) > 0 {
+	// Only when there are headers to order. The order key counts as a header
+	// too, and the client's default headers apply to an empty set only, so an
+	// order on its own kept them from ever applying.
+	if len(headers) > 0 && len(input.HeaderOrder) > 0 {
 		headers[http.HeaderOrderKey] = input.HeaderOrder
 	}
 

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -142,7 +142,12 @@ func BuildRequest(input RequestInput) (*http.Request, *TLSClientError) {
 		headers[key] = []string{value}
 	}
 
-	headers[http.HeaderOrderKey] = input.HeaderOrder
+	// Only when an order was given. An empty order still counts as a header,
+	// and the client's default headers apply to an empty set only, so putting
+	// it here unconditionally kept them from ever applying.
+	if len(input.HeaderOrder) > 0 {
+		headers[http.HeaderOrderKey] = input.HeaderOrder
+	}
 
 	tlsReq.Header = headers
 

--- a/cffi_src/factory.go
+++ b/cffi_src/factory.go
@@ -440,6 +440,13 @@ func getTlsClient(requestInput RequestInput, sessionId string, withSession bool)
 
 	if requestInput.DefaultHeaders != nil && len(requestInput.DefaultHeaders) != 0 {
 		options = append(options, tls_client.WithDefaultHeaders(requestInput.DefaultHeaders))
+	} else if len(requestInput.Headers) == 0 && requestInput.TLSClientIdentifier != "" {
+		// A browser profile and no headers at all: the browser's own headers
+		// go out instead of Go-http-client. Any header the caller sets turns
+		// this off, and so does a defaultHeaders of their own.
+		if headers, ok := getTlsClientProfile(requestInput.TLSClientIdentifier).DefaultHeaders(); ok {
+			options = append(options, tls_client.WithDefaultHeaders(headers))
+		}
 	}
 
 	if requestInput.ConnectHeaders != nil && len(requestInput.ConnectHeaders) != 0 {

--- a/default_headers_test.go
+++ b/default_headers_test.go
@@ -1,0 +1,296 @@
+package tls_client
+
+import (
+	"bufio"
+	"crypto/tls"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	http "github.com/bogdanfinn/fhttp"
+	"github.com/bogdanfinn/fhttp/http2"
+	"github.com/bogdanfinn/fhttp/http2/hpack"
+	"github.com/bogdanfinn/tls-client/profiles"
+)
+
+// What Chrome 152 on Windows sent to a local server for a top-level navigation
+// on 2026-09-08, read off the wire: the HPACK block decoded field by field over
+// HTTP/2, the raw lines over HTTP/1.1. HOST stands for the address. A client
+// given the profile's DefaultHeaders and nothing else has to arrive the same
+// way, on both protocols, because what leaves the map is not what reaches the
+// wire: the transport writes Host, strips Connection over HTTP/2, and would add
+// its own accept-encoding if it did not recognise ours.
+var chrome152OverHTTP2 = [][2]string{
+	{":method", "GET"}, {":authority", "HOST"}, {":scheme", "https"}, {":path", "/"},
+	{"sec-ch-ua", `"Chromium";v="152", "Not?A_Brand";v="24", "Google Chrome";v="152"`},
+	{"sec-ch-ua-mobile", "?0"},
+	{"sec-ch-ua-platform", `"Windows"`},
+	{"upgrade-insecure-requests", "1"},
+	{"user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36"},
+	{"accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"},
+	{"sec-fetch-site", "none"},
+	{"sec-fetch-mode", "navigate"},
+	{"sec-fetch-user", "?1"},
+	{"sec-fetch-dest", "document"},
+	{"accept-encoding", "gzip, deflate, br, zstd"},
+	{"accept-language", "en-US,en;q=0.9"},
+	{"priority", "u=0, i"},
+}
+
+var chrome152OverHTTP1 = [][2]string{
+	{"Host", "HOST"},
+	{"Connection", "keep-alive"},
+	{"sec-ch-ua", `"Chromium";v="152", "Not?A_Brand";v="24", "Google Chrome";v="152"`},
+	{"sec-ch-ua-mobile", "?0"},
+	{"sec-ch-ua-platform", `"Windows"`},
+	{"Upgrade-Insecure-Requests", "1"},
+	{"User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36"},
+	{"Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"},
+	{"Sec-Fetch-Site", "none"},
+	{"Sec-Fetch-Mode", "navigate"},
+	{"Sec-Fetch-User", "?1"},
+	{"Sec-Fetch-Dest", "document"},
+	{"Accept-Encoding", "gzip, deflate, br, zstd"},
+	{"Accept-Language", "en-US,en;q=0.9"},
+}
+
+func TestDefaultHeadersArriveTheWayChromeSendsThem(t *testing.T) {
+	headers, ok := profiles.Chrome_152.DefaultHeaders()
+	if !ok {
+		t.Fatal("Chrome_152 has no default headers")
+	}
+
+	t.Run("HTTP/2", func(t *testing.T) {
+		got := recordOneRequest(t, "h2", func(addr string) {
+			get(t, addr, WithClientProfile(profiles.Chrome_152), WithDefaultHeaders(headers))
+		})
+		compareWire(t, got, chrome152OverHTTP2)
+	})
+
+	t.Run("HTTP/1.1", func(t *testing.T) {
+		// The documented step: the browser sends no priority over HTTP/1.1.
+		h1 := headers.Clone()
+		delete(h1, "priority")
+		got := recordOneRequest(t, "http/1.1", func(addr string) {
+			get(t, addr, WithClientProfile(profiles.Chrome_152), WithDefaultHeaders(h1), WithForceHttp1())
+		})
+		compareWire(t, got, chrome152OverHTTP1)
+	})
+}
+
+// A request with its own headers is left alone: the defaults only stand in for
+// an empty set.
+func TestDefaultHeadersDoNotTouchARequestThatHasHeaders(t *testing.T) {
+	headers, _ := profiles.Chrome_152.DefaultHeaders()
+	got := recordOneRequest(t, "h2", func(addr string) {
+		client, err := NewHttpClient(NewNoopLogger(), WithClientProfile(profiles.Chrome_152), WithDefaultHeaders(headers), WithInsecureSkipVerify(), WithNotFollowRedirects())
+		if err != nil {
+			t.Fatal(err)
+		}
+		req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header = http.Header{"x-mine": {"1"}}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	})
+	names := make([]string, 0, len(got))
+	for _, kv := range got {
+		names = append(names, kv[0])
+	}
+	joined := strings.Join(names, " ")
+	if !strings.Contains(joined, "x-mine") || strings.Contains(joined, "sec-ch-ua") {
+		t.Errorf("the request's own headers were replaced: %s", joined)
+	}
+}
+
+func get(t *testing.T, addr string, options ...HttpClientOption) {
+	t.Helper()
+	options = append(options, WithInsecureSkipVerify(), WithNotFollowRedirects(), WithTimeoutSeconds(10))
+	client, err := NewHttpClient(NewNoopLogger(), options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodGet, "https://"+addr+"/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+}
+
+func compareWire(t *testing.T, got, want [][2]string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Errorf("%d headers arrived, Chrome sends %d:\n%s", len(got), len(want), render(got))
+	}
+	for i := range want {
+		if i >= len(got) {
+			break
+		}
+		name, value := want[i][0], want[i][1]
+		if got[i][0] != name {
+			t.Errorf("position %d: %s, Chrome sends %s", i, got[i][0], name)
+			continue
+		}
+		if value != "HOST" && got[i][1] != value {
+			t.Errorf("%s: %q, Chrome sends %q", name, got[i][1], value)
+		}
+	}
+}
+
+func render(kvs [][2]string) string {
+	var b strings.Builder
+	for _, kv := range kvs {
+		b.WriteString("  " + kv[0] + ": " + kv[1] + "\n")
+	}
+	return b.String()
+}
+
+// recordOneRequest serves one TLS connection speaking only proto, records the
+// first request's headers in arrival order, answers it with an empty 200, and
+// returns what arrived. Over HTTP/2 the HPACK block is decoded field by field,
+// so pseudo-headers and order survive; over HTTP/1.1 the lines are read raw,
+// so the spelling survives too.
+func recordOneRequest(t *testing.T, proto string, do func(addr string)) [][2]string {
+	t.Helper()
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{testCert(t)},
+		NextProtos:   []string{proto},
+		MinVersion:   tls.VersionTLS12,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	recorded := make(chan [][2]string, 1)
+	failed := make(chan error, 1)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			failed <- err
+			return
+		}
+		defer conn.Close()
+		conn.SetDeadline(time.Now().Add(10 * time.Second))
+		tlsConn := conn.(*tls.Conn)
+		if err := tlsConn.Handshake(); err != nil {
+			failed <- err
+			return
+		}
+		var hdrs [][2]string
+		if tlsConn.ConnectionState().NegotiatedProtocol == "h2" {
+			hdrs, err = serveOneHTTP2(tlsConn)
+		} else {
+			hdrs, err = serveOneHTTP1(tlsConn)
+		}
+		if err != nil {
+			failed <- err
+			return
+		}
+		recorded <- hdrs
+		// The client keeps talking after its request, a settings ack for
+		// one. Closing with that unread turns the close into a reset, and
+		// the client can then lose the response it was about to read. So
+		// drain until the test is done with the client, and close then.
+		go io.Copy(io.Discard, tlsConn)
+		<-done
+	}()
+
+	do(ln.Addr().String())
+
+	select {
+	case hdrs := <-recorded:
+		return hdrs
+	case err := <-failed:
+		t.Fatalf("the server did not get a request: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the server did not get a request in time")
+	}
+	return nil
+}
+
+func serveOneHTTP1(conn net.Conn) ([][2]string, error) {
+	br := bufio.NewReader(conn)
+	if _, err := br.ReadString('\n'); err != nil { // the request line
+		return nil, err
+	}
+	var hdrs [][2]string
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return nil, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		name, value, _ := strings.Cut(line, ":")
+		hdrs = append(hdrs, [2]string{name, strings.TrimSpace(value)})
+	}
+	_, err := io.WriteString(conn, "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+	return hdrs, err
+}
+
+func serveOneHTTP2(conn net.Conn) ([][2]string, error) {
+	preface := make([]byte, len(http2.ClientPreface))
+	if _, err := io.ReadFull(conn, preface); err != nil {
+		return nil, err
+	}
+	fr := http2.NewFramer(conn, conn)
+	if err := fr.WriteSettings(); err != nil {
+		return nil, err
+	}
+	var hdrs [][2]string
+	dec := hpack.NewDecoder(65536, func(f hpack.HeaderField) {
+		hdrs = append(hdrs, [2]string{f.Name, f.Value})
+	})
+	for {
+		f, err := fr.ReadFrame()
+		if err != nil {
+			return nil, err
+		}
+		var block []byte
+		var stream uint32
+		var ended bool
+		switch f := f.(type) {
+		case *http2.SettingsFrame:
+			if !f.IsAck() {
+				if err := fr.WriteSettingsAck(); err != nil {
+					return nil, err
+				}
+			}
+			continue
+		case *http2.HeadersFrame:
+			block, stream, ended = f.HeaderBlockFragment(), f.StreamID, f.HeadersEnded()
+		case *http2.ContinuationFrame:
+			block, stream, ended = f.HeaderBlockFragment(), f.StreamID, f.HeadersEnded()
+		default:
+			continue
+		}
+		if _, err := dec.Write(block); err != nil {
+			return nil, err
+		}
+		if !ended {
+			continue
+		}
+		var buf strings.Builder
+		enc := hpack.NewEncoder(&buf)
+		enc.WriteField(hpack.HeaderField{Name: ":status", Value: "200"})
+		enc.WriteField(hpack.HeaderField{Name: "content-length", Value: "0"})
+		err = fr.WriteHeaders(http2.HeadersFrameParam{StreamID: stream, BlockFragment: []byte(buf.String()), EndHeaders: true, EndStream: true})
+		return hdrs, err
+	}
+}

--- a/profiles/headers.go
+++ b/profiles/headers.go
@@ -28,9 +28,11 @@ const (
 // Chrome 123, the priority header from Chrome 124.
 //
 // The set is what the browser sends over HTTP/2, which this client negotiates
-// by default. Over HTTP/1.1 the browser sends Host and Connection first, which
-// the client writes for you, and no priority header; with WithForceHttp1,
-// delete(headers, "priority") first. Names carry the browser's HTTP/1.1
+// by default. Over HTTP/1.1 the browser sends Host first, which the client
+// writes for you and which is therefore in the order and not in the set, then
+// Connection, which is in the set and which HTTP/2 leaves out, and it sends
+// no priority header; with WithForceHttp1, delete(headers, "priority") first.
+// Names carry the browser's HTTP/1.1
 // spelling, lower case for the client hints and capitals elsewhere, because
 // HTTP/1.1 puts a name on the wire as it is written; HTTP/2 lower-cases every
 // name.

--- a/profiles/headers.go
+++ b/profiles/headers.go
@@ -1,0 +1,153 @@
+package profiles
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	http "github.com/bogdanfinn/fhttp"
+)
+
+// The Chrome releases that changed what a navigation sends.
+const (
+	clientHintsSince = 89  // sec-ch-ua, sec-ch-ua-mobile and sec-ch-ua-platform on every request
+	zstdSince        = 123 // zstd joined accept-encoding
+	prioritySince    = 124 // the priority header, over HTTP/2 and HTTP/3
+)
+
+// DefaultHeaders returns the request headers the browser this profile imitates
+// sends on a top-level navigation from Windows, in the order it sends them, as
+// a set for WithDefaultHeaders. The second result is false for a profile whose
+// browser is not mapped, and nothing is returned then, so a guess never goes on
+// the wire.
+//
+// Chrome and Brave are mapped. The values and the order were read off the wire
+// from Chrome, Edge and Brave 152 over HTTP/1.1 and HTTP/2, and the sec-ch-ua
+// list is built the way Chromium builds it, see secChUA. What changed with a
+// Chrome release follows the profile's major: zstd in accept-encoding from
+// Chrome 123, the priority header from Chrome 124.
+//
+// The set is what the browser sends over HTTP/2, which this client negotiates
+// by default. Over HTTP/1.1 the browser sends Host and Connection first, which
+// the client writes for you, and no priority header; with WithForceHttp1,
+// delete(headers, "priority") first. Names carry the browser's HTTP/1.1
+// spelling, lower case for the client hints and capitals elsewhere, because
+// HTTP/1.1 puts a name on the wire as it is written; HTTP/2 lower-cases every
+// name.
+//
+// Firefox, Safari and Opera are not mapped: their header sets have not been
+// read off the wire here, and a set written from memory is what this exists to
+// replace.
+func (c ClientProfile) DefaultHeaders() (http.Header, bool) {
+	var brand string
+	switch c.clientHelloId.Client {
+	case "Chrome":
+		brand = "Google Chrome"
+	case "Brave":
+		brand = "Brave"
+	default:
+		return nil, false
+	}
+	major, ok := majorOf(c.clientHelloId.Version)
+	if !ok || major < clientHintsSince {
+		return nil, false
+	}
+	brave := brand == "Brave"
+
+	accept := "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"
+	if !brave {
+		// Brave does not offer signed exchanges.
+		accept += ",application/signed-exchange;v=b3;q=0.7"
+	}
+	encoding := "gzip, deflate, br"
+	if major >= zstdSince {
+		encoding += ", zstd"
+	}
+	language := "en-US,en;q=0.9"
+	if brave {
+		// Brave changes the q value from one session to the next; 0.5, 0.7
+		// and 0.8 were all seen from one build. Any of them is what a real
+		// Brave sends.
+		language = "en-US,en;q=0.7"
+	}
+
+	type field struct{ name, value string }
+	fields := []field{
+		{"Connection", "keep-alive"},
+		{"sec-ch-ua", secChUA(major, brand)},
+		{"sec-ch-ua-mobile", "?0"},
+		{"sec-ch-ua-platform", `"Windows"`},
+		{"Upgrade-Insecure-Requests", "1"},
+		{"User-Agent", fmt.Sprintf("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/%d.0.0.0 Safari/537.36", major)},
+		{"Accept", accept},
+	}
+	if brave {
+		fields = append(fields, field{"Sec-GPC", "1"})
+	}
+	fields = append(fields,
+		field{"Sec-Fetch-Site", "none"},
+		field{"Sec-Fetch-Mode", "navigate"},
+		field{"Sec-Fetch-User", "?1"},
+		field{"Sec-Fetch-Dest", "document"},
+		field{"Accept-Encoding", encoding},
+		field{"Accept-Language", language},
+	)
+	if major >= prioritySince {
+		fields = append(fields, field{"priority", "u=0, i"})
+	}
+
+	headers := make(http.Header, len(fields)+1)
+	// Host is not in the set: the client writes it, over HTTP/1.1 through the
+	// header map, so it takes the browser's place from the order.
+	order := []string{"host"}
+	for _, f := range fields {
+		headers[f.name] = []string{f.value}
+		order = append(order, strings.ToLower(f.name))
+	}
+	headers[http.HeaderOrderKey] = order
+	return headers, true
+}
+
+// majorOf reads the leading number of a profile version, "152" as well as
+// "152_PSK".
+func majorOf(version string) (int, bool) {
+	i := 0
+	for i < len(version) && version[i] >= '0' && version[i] <= '9' {
+		i++
+	}
+	n, err := strconv.Atoi(version[:i])
+	return n, err == nil
+}
+
+// secChUA builds the sec-ch-ua value the way Chromium does, from
+// components/embedder_support/user_agent_utils.cc. The list has three entries:
+// an arbitrary brand, Chromium, and the browser's own brand. The arbitrary
+// brand is "Not" + a character + "A" + a character + "Brand", with both
+// characters and the version taken from tables indexed by the major, and the
+// three entries are then placed by a permutation table indexed by the major
+// too. Every part of the value therefore changes with the version, and a value
+// copied from an older capture and bumped by hand keeps the wrong brand in the
+// wrong place.
+//
+// Checked against what Brave 148 and 151 and Chrome, Edge and Brave 152 sent.
+func secChUA(major int, brand string) string {
+	chars := []string{" ", "(", ":", "-", ".", "/", ")", ";", "=", "?", "_"}
+	versions := []string{"8", "99", "24"}
+	orders := [][3]int{{0, 1, 2}, {0, 2, 1}, {1, 0, 2}, {1, 2, 0}, {2, 0, 1}, {2, 1, 0}}
+
+	grease := "Not" + chars[major%len(chars)] + "A" + chars[(major+1)%len(chars)] + "Brand"
+	entries := [3]string{
+		fmt.Sprintf(`"%s";v="%s"`, grease, versions[major%len(versions)]),
+		fmt.Sprintf(`"Chromium";v="%d"`, major),
+		fmt.Sprintf(`"%s";v="%d"`, brand, major),
+	}
+
+	// The table says where each entry goes, not which entry comes next:
+	// placed[order[i]] = entries[i]. Read the other way round it gives the
+	// wrong order for four majors out of six, 148 among them.
+	var placed [3]string
+	for i, pos := range orders[major%len(orders)] {
+		placed[pos] = entries[i]
+	}
+	return strings.Join(placed[:], ", ")
+}

--- a/profiles/headers_test.go
+++ b/profiles/headers_test.go
@@ -1,0 +1,195 @@
+package profiles
+
+import (
+	"strings"
+	"testing"
+
+	http "github.com/bogdanfinn/fhttp"
+)
+
+// What Chrome 152 on Windows sent to a local server for a top-level
+// navigation, read off the HTTP/2 frames on 2026-09-08. Host and Connection
+// come from the HTTP/1.1 reading of the same browser; the client writes Host
+// itself, so it is in the order and not in the set.
+var chrome152 = []struct{ name, value string }{
+	{"host", ""},
+	{"connection", "keep-alive"},
+	{"sec-ch-ua", `"Chromium";v="152", "Not?A_Brand";v="24", "Google Chrome";v="152"`},
+	{"sec-ch-ua-mobile", "?0"},
+	{"sec-ch-ua-platform", `"Windows"`},
+	{"upgrade-insecure-requests", "1"},
+	{"user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36"},
+	{"accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"},
+	{"sec-fetch-site", "none"},
+	{"sec-fetch-mode", "navigate"},
+	{"sec-fetch-user", "?1"},
+	{"sec-fetch-dest", "document"},
+	{"accept-encoding", "gzip, deflate, br, zstd"},
+	{"accept-language", "en-US,en;q=0.9"},
+	{"priority", "u=0, i"},
+}
+
+func TestDefaultHeadersMatchWhatChrome152Sent(t *testing.T) {
+	headers, ok := Chrome_152.DefaultHeaders()
+	if !ok {
+		t.Fatal("Chrome_152 has no default headers")
+	}
+
+	order := headers[http.HeaderOrderKey]
+	if len(order) != len(chrome152) {
+		t.Fatalf("the order names %d headers, Chrome sent %d:\n%v", len(order), len(chrome152), order)
+	}
+	for i, want := range chrome152 {
+		if order[i] != want.name {
+			t.Errorf("position %d: %s, Chrome sends %s", i, order[i], want.name)
+		}
+		if want.name == "host" {
+			continue
+		}
+		got, found := valueOf(headers, want.name)
+		if !found {
+			t.Errorf("%s is missing", want.name)
+		} else if got != want.value {
+			t.Errorf("%s is %q, Chrome sends %q", want.name, got, want.value)
+		}
+	}
+}
+
+// valueOf finds a header whatever its spelling, since the set uses the
+// browser's HTTP/1.1 spelling and the order is lower case.
+func valueOf(h http.Header, name string) (string, bool) {
+	for k, v := range h {
+		if strings.EqualFold(k, name) && len(v) > 0 {
+			return v[0], true
+		}
+	}
+	return "", false
+}
+
+// The names are spelled as Chrome spells them over HTTP/1.1, where the
+// spelling reaches the wire: the client hints in lower case, the rest with
+// capitals.
+func TestDefaultHeadersUseTheBrowsersSpelling(t *testing.T) {
+	headers, _ := Chrome_152.DefaultHeaders()
+	for _, name := range []string{"sec-ch-ua", "sec-ch-ua-mobile", "sec-ch-ua-platform", "User-Agent", "Accept", "Sec-Fetch-Site", "Upgrade-Insecure-Requests", "Accept-Encoding", "Accept-Language", "Connection"} {
+		if _, ok := headers[name]; !ok {
+			t.Errorf("no header spelled %q", name)
+		}
+	}
+	brave, _ := Brave_146.DefaultHeaders()
+	if _, ok := brave["Sec-GPC"]; !ok {
+		t.Error("Brave's Sec-GPC is not spelled the way Brave spells it")
+	}
+}
+
+// Five brand lists read off the wire. 148 is the one that tells a placement
+// from a selection: reading the permutation table the other way round gives
+// Chromium, Not/A)Brand, Brave for it.
+func TestSecChUAMatchesTheCaptures(t *testing.T) {
+	captures := []struct {
+		major int
+		brand string
+		sent  string
+	}{
+		{148, "Brave", `"Chromium";v="148", "Brave";v="148", "Not/A)Brand";v="99"`},
+		{151, "Brave", `"Not=A?Brand";v="99", "Brave";v="151", "Chromium";v="151"`},
+		{152, "Brave", `"Chromium";v="152", "Not?A_Brand";v="24", "Brave";v="152"`},
+		{152, "Google Chrome", `"Chromium";v="152", "Not?A_Brand";v="24", "Google Chrome";v="152"`},
+		{152, "Microsoft Edge", `"Chromium";v="152", "Not?A_Brand";v="24", "Microsoft Edge";v="152"`},
+		// The example in issue #213, which its author took from a real Chrome 133.
+		{133, "Google Chrome", `"Not(A:Brand";v="99", "Google Chrome";v="133", "Chromium";v="133"`},
+	}
+	for _, c := range captures {
+		if got := secChUA(c.major, c.brand); got != c.sent {
+			t.Errorf("%s %d:\n got  %s\n sent %s", c.brand, c.major, got, c.sent)
+		}
+	}
+}
+
+func TestOnlyChromeAndBraveHaveDefaultHeaders(t *testing.T) {
+	for name, profile := range map[string]ClientProfile{
+		"firefox_133": Firefox_133, "firefox_148": Firefox_148, "safari_16_0": Safari_16_0,
+		"safari_ios_18_0": Safari_IOS_18_0, "opera_90": Opera_90, "okhttp4_android_13": Okhttp4Android13,
+		"zalando_ios_mobile": ZalandoIosMobile, "cloudscraper": CloudflareCustom,
+	} {
+		if headers, ok := profile.DefaultHeaders(); ok || headers != nil {
+			t.Errorf("%s has default headers: %v", name, headers)
+		}
+	}
+	for name, profile := range map[string]ClientProfile{"chrome_103": Chrome_103, "chrome_152_PSK": Chrome_152_PSK, "brave_146": Brave_146} {
+		if _, ok := profile.DefaultHeaders(); !ok {
+			t.Errorf("%s has no default headers", name)
+		}
+	}
+}
+
+func TestBraveDiffersFromChromeWhereBraveDiffers(t *testing.T) {
+	headers, _ := Brave_146.DefaultHeaders()
+	if got, _ := valueOf(headers, "sec-ch-ua"); got != `"Chromium";v="146", "Not-A.Brand";v="24", "Brave";v="146"` {
+		t.Errorf("sec-ch-ua: %s", got)
+	}
+	if got, _ := valueOf(headers, "accept"); strings.Contains(got, "signed-exchange") {
+		t.Errorf("Brave offers signed exchanges: %s", got)
+	}
+	if got, _ := valueOf(headers, "user-agent"); !strings.Contains(got, "Chrome/146.0.0.0") || strings.Contains(got, "Brave") {
+		t.Errorf("Brave's User-Agent is Chrome's, unchanged: %s", got)
+	}
+	order := headers[http.HeaderOrderKey]
+	for i, n := range order {
+		if n == "sec-gpc" && (i == 0 || order[i-1] != "accept") {
+			t.Errorf("sec-gpc follows %s, Brave sends it after accept", order[i-1])
+		}
+	}
+}
+
+func TestWhatFollowsTheMajor(t *testing.T) {
+	tests := []struct {
+		profile  ClientProfile
+		zstd     bool
+		priority bool
+	}{
+		{Chrome_120, false, false},
+		{Chrome_124, true, true},
+		{Chrome_133, true, true},
+	}
+	for _, tt := range tests {
+		headers, _ := tt.profile.DefaultHeaders()
+		encoding, _ := valueOf(headers, "accept-encoding")
+		if strings.Contains(encoding, "zstd") != tt.zstd {
+			t.Errorf("%s: accept-encoding is %q", tt.profile.GetClientHelloStr(), encoding)
+		}
+		if _, ok := valueOf(headers, "priority"); ok != tt.priority {
+			t.Errorf("%s: priority present = %v", tt.profile.GetClientHelloStr(), ok)
+		}
+	}
+}
+
+// Every header is in the order and every name in the order is a header, host
+// aside, for every mapped profile. A header left out of the order lands after
+// the ordered ones, quietly.
+func TestEveryDefaultHeaderIsOrdered(t *testing.T) {
+	for name, profile := range MappedTLSClients {
+		headers, ok := profile.DefaultHeaders()
+		if !ok {
+			continue
+		}
+		order := headers[http.HeaderOrderKey]
+		seen := map[string]int{}
+		for _, n := range order {
+			seen[n]++
+			if n != "host" {
+				if _, found := valueOf(headers, n); !found {
+					t.Errorf("%s: %s is in the order and not in the set", name, n)
+				}
+			}
+		}
+		for k := range headers {
+			if k == http.HeaderOrderKey {
+				continue
+			}
+			if seen[strings.ToLower(k)] != 1 {
+				t.Errorf("%s: %s appears %d times in the order", name, k, seen[strings.ToLower(k)])
+			}
+		}
+	}
+}


### PR DESCRIPTION
For #213.

A request with no headers goes out as `Go-http-client`, whatever profile the client has. `ClientProfile.DefaultHeaders()` returns the headers the profile's browser sends on a top-level navigation from Windows, in the order it sends them, as a set for `WithDefaultHeaders`. The Chrome and Brave profiles are mapped. For anything else it returns false and nothing, so nothing guessed goes on the wire. Firefox and Safari are not mapped: their sets have not been read off the wire here, and a set written from memory is what this exists to replace.

Through the shared library the set is used when a request names a browser profile and carries neither `headers` nor `defaultHeaders`, which is what the issue asks for. Any header the caller sets turns it off.

What the values are based on. The set was read off the wire from Chrome, Edge and Brave 152 on Windows, headless, against local servers that keep headers in arrival order, over HTTP/1.1 and HTTP/2. The `sec-ch-ua` list is built the way Chromium builds it (`components/embedder_support/user_agent_utils.cc`): the arbitrary brand's characters, its version and the position of the three entries all follow the major version. That was checked against captures of Brave 148 and 151 and of Chrome, Edge and Brave 152, and against the example in the issue, which is a real Chrome 133. Two thresholds follow the major as well: zstd in `accept-encoding` from Chrome 123, the `priority` header from Chrome 124.

Two things about the wire shaped the set. Over HTTP/1.1 Chromium spells the client hints in lower case and every other name with capitals, and fhttp writes a name as it is stored, so the set uses that spelling; HTTP/2 lower-cases every name anyway. And fhttp writes `Host` through the header map on HTTP/1.1, so the order starts with `host` although the set does not contain it: a name missing from the order lands after all the ordered ones.

A bug on the way. `BuildRequest` in the shared library always put `Header-Order:` on the request, with nothing in it when the caller gave no order. That one entry made the header map non-empty, and default headers only replace an empty map, so `defaultHeaders` had never applied through the shared library. The key is set only when an order was given now, and a test pins it.

Tests. `default_headers_test.go` in the root package starts a TLS server that speaks only HTTP/2, decodes the HPACK block field by field and compares what arrived, pseudo-headers included, with what Chrome 152 sent to the same kind of server; then the same over HTTP/1.1 from the raw lines, where the spelling and the place of `Host` and `Connection` are visible. Both match. The profile tests hold the captured brand lists; 148 is the control for the permutation table being a placement and not a selection, since read the other way round it gives the wrong order for four majors out of six. The shared library tests cover the empty header map and a request with and without headers of its own.

The set is what the browser sends over HTTP/2, which the client negotiates by default. Over HTTP/1.1 the browser sends no `priority` header, so with `WithForceHttp1` the README says to `delete(headers, "priority")` first, and the HTTP/1.1 test does the same.
