### PR TITLE
Add Chrome 153 and Chrome 153 PSK profiles, trust_anchors payload

### DIFF
--- a/profiles/extension_data.go
+++ b/profiles/extension_data.go
@@ -33,6 +33,14 @@ const chrome152TrustAnchorsCapture = "00b80582df13020108839a648c9b2d010c08839a64
 
 var chrome152TrustAnchors = shuffleTrustAnchors(mustSplitTrustAnchors(chrome152TrustAnchorsCapture))
 
+// Stable Chrome 153.0.8010.37 on Windows 11 25H2 (fresh user profile). 186 bytes,
+// 28 IDs, same anchor set as Chrome 152 in a different absl::flat_hash_set
+// iteration order. Chrome Root Store 39, no MTC anchors (VerifyMTCs off by
+// default). Captured 2026-09-09 via https://tls.peet.ws/api/all.
+const chrome153TrustAnchorsCapture = "00b80582df13020d08839a648c9b2d01070582df13021408839a648c9b2d010a04d679090708839a648c9b2d01090582df13020e04d679090108839a648c9b2d010808839a648c9b2d010b04d679090f04d679090408839a648c9b2d010d04d679090c08839a648c9b2d010c04d67909060582df13021204d679090808839a648c9b2d011204d67909050582df13020604d679090b0582df13021304d679090d0582df13020108839a648c9b2d011304d679090a0582df13020f"
+
+var chrome153TrustAnchors = shuffleTrustAnchors(mustSplitTrustAnchors(chrome153TrustAnchorsCapture))
+
 // mustDecodeHex converts a wire-format hex string into extension data. It
 // panics on malformed input, which can only come from a literal in this
 // package.

--- a/profiles/internal_browser_profiles.go
+++ b/profiles/internal_browser_profiles.go
@@ -5,6 +5,245 @@ import (
 	tls "github.com/bogdanfinn/utls"
 )
 
+var Chrome_153_PSK = ClientProfile{
+	clientHelloId: tls.ClientHelloID{
+		Client:               "Chrome",
+		RandomExtensionOrder: false,
+		Version:              "153_PSK",
+		Seed:                 nil,
+		SpecFactory: func() (tls.ClientHelloSpec, error) {
+			return tls.ClientHelloSpec{
+				CipherSuites: []uint16{
+					tls.GREASE_PLACEHOLDER,
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+				},
+				CompressionMethods: []byte{
+					tls.CompressionNone,
+				},
+				Extensions: []tls.TLSExtension{
+					&tls.UtlsGREASEExtension{},
+					&tls.ApplicationSettingsExtensionNew{
+						SupportedProtocols: []string{"h2"},
+					},
+					&tls.SupportedVersionsExtension{Versions: []uint16{
+						tls.GREASE_PLACEHOLDER,
+						tls.VersionTLS13,
+						tls.VersionTLS12,
+					}},
+					&tls.SCTExtension{},
+					tls.BoringGREASEECH(),
+					&tls.KeyShareExtension{KeyShares: []tls.KeyShare{
+						{Group: tls.CurveID(tls.GREASE_PLACEHOLDER), Data: []byte{0}},
+						{Group: tls.X25519MLKEM768},
+						{Group: tls.X25519},
+					}},
+					&tls.SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []tls.SignatureScheme{
+						// Chrome 153 sends a GREASE value as the first
+						// signature algorithm and picks a new one per connection.
+						randomGREASESignatureScheme(),
+						tls.SignatureScheme(0x0904),
+						tls.SignatureScheme(0x0905),
+						tls.SignatureScheme(0x0906),
+						tls.ECDSAWithP256AndSHA256,
+						tls.PSSWithSHA256,
+						tls.PKCS1WithSHA256,
+						tls.ECDSAWithP384AndSHA384,
+						tls.PSSWithSHA384,
+						tls.PKCS1WithSHA384,
+						tls.PSSWithSHA512,
+						tls.PKCS1WithSHA512,
+					}},
+					&tls.SupportedCurvesExtension{Curves: []tls.CurveID{
+						tls.GREASE_PLACEHOLDER,
+						tls.X25519MLKEM768,
+						tls.X25519,
+						tls.CurveP256,
+						tls.CurveP384,
+					}},
+					&tls.UtlsCompressCertExtension{Algorithms: []tls.CertCompressionAlgo{
+						tls.CertCompressionBrotli,
+					}},
+					&tls.ExtendedMasterSecretExtension{},
+					&tls.SessionTicketExtension{},
+					&tls.SNIExtension{},
+					&tls.RenegotiationInfoExtension{
+						Renegotiation: tls.RenegotiateOnceAsClient,
+					},
+					&tls.PSKKeyExchangeModesExtension{Modes: []uint8{
+						tls.PskModeDHE,
+					}},
+					&tls.SupportedPointsExtension{SupportedPoints: []byte{
+						tls.PointFormatUncompressed,
+					}},
+					&tls.StatusRequestExtension{},
+					&tls.ALPNExtension{AlpnProtocols: []string{
+						"h2",
+						"http/1.1",
+					}},
+					// server_padding (0x12e0, BoringSSL-internal, payload 4000) is
+					// Beta-only. Stable omits it. Uncomment to match Beta.
+					// &tls.GenericExtension{Id: 0x12e0, Data: []byte{0x0f, 0xa0}},
+					&tls.GenericExtension{Id: 0xca34, Data: chrome153TrustAnchors}, // https://source.chromium.org/search?q=TLSEXT_TYPE_trust_anchors https://issues.chromium.org/issues/398275713
+					&tls.UtlsGREASEExtension{},
+					&tls.UtlsPreSharedKeyExtension{},
+				},
+			}, nil
+		},
+	},
+	settings: map[http2.SettingID]uint32{
+		http2.SettingHeaderTableSize:   65536,
+		http2.SettingEnablePush:        0,
+		http2.SettingInitialWindowSize: 6291456,
+		http2.SettingMaxHeaderListSize: 262144,
+	},
+	settingsOrder: []http2.SettingID{
+		http2.SettingHeaderTableSize,
+		http2.SettingEnablePush,
+		http2.SettingInitialWindowSize,
+		http2.SettingMaxHeaderListSize,
+	},
+	pseudoHeaderOrder: []string{
+		":method",
+		":authority",
+		":scheme",
+		":path",
+	},
+	connectionFlow: 15663105,
+}
+
+var Chrome_153 = ClientProfile{
+	clientHelloId: tls.ClientHelloID{
+		Client:               "Chrome",
+		RandomExtensionOrder: false,
+		Version:              "153",
+		Seed:                 nil,
+		SpecFactory: func() (tls.ClientHelloSpec, error) {
+			return tls.ClientHelloSpec{
+				CipherSuites: []uint16{
+					tls.GREASE_PLACEHOLDER,
+					tls.TLS_AES_128_GCM_SHA256,
+					tls.TLS_AES_256_GCM_SHA384,
+					tls.TLS_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+					tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+				},
+				CompressionMethods: []byte{
+					tls.CompressionNone,
+				},
+				Extensions: []tls.TLSExtension{
+					&tls.UtlsGREASEExtension{},
+					&tls.KeyShareExtension{KeyShares: []tls.KeyShare{
+						{Group: tls.CurveID(tls.GREASE_PLACEHOLDER), Data: []byte{0}},
+						{Group: tls.X25519MLKEM768},
+						{Group: tls.X25519},
+					}},
+					&tls.SNIExtension{},
+					&tls.ApplicationSettingsExtensionNew{
+						SupportedProtocols: []string{"h2"},
+					},
+					&tls.RenegotiationInfoExtension{
+						Renegotiation: tls.RenegotiateOnceAsClient,
+					},
+					&tls.SupportedCurvesExtension{Curves: []tls.CurveID{
+						tls.GREASE_PLACEHOLDER,
+						tls.X25519MLKEM768,
+						tls.X25519,
+						tls.CurveP256,
+						tls.CurveP384,
+					}},
+					&tls.UtlsCompressCertExtension{Algorithms: []tls.CertCompressionAlgo{
+						tls.CertCompressionBrotli,
+					}},
+					&tls.SessionTicketExtension{},
+					&tls.StatusRequestExtension{},
+					&tls.ExtendedMasterSecretExtension{},
+					&tls.SupportedVersionsExtension{Versions: []uint16{
+						tls.GREASE_PLACEHOLDER,
+						tls.VersionTLS13,
+						tls.VersionTLS12,
+					}},
+					&tls.SignatureAlgorithmsExtension{SupportedSignatureAlgorithms: []tls.SignatureScheme{
+						// Chrome 153 sends a GREASE value as the first
+						// signature algorithm and picks a new one per connection.
+						randomGREASESignatureScheme(),
+						tls.SignatureScheme(0x0904),
+						tls.SignatureScheme(0x0905),
+						tls.SignatureScheme(0x0906),
+						tls.ECDSAWithP256AndSHA256,
+						tls.PSSWithSHA256,
+						tls.PKCS1WithSHA256,
+						tls.ECDSAWithP384AndSHA384,
+						tls.PSSWithSHA384,
+						tls.PKCS1WithSHA384,
+						tls.PSSWithSHA512,
+						tls.PKCS1WithSHA512,
+					}},
+					&tls.SCTExtension{},
+					&tls.SupportedPointsExtension{SupportedPoints: []byte{
+						tls.PointFormatUncompressed,
+					}},
+					tls.BoringGREASEECH(),
+					&tls.ALPNExtension{AlpnProtocols: []string{
+						"h2",
+						"http/1.1",
+					}},
+					&tls.PSKKeyExchangeModesExtension{Modes: []uint8{
+						tls.PskModeDHE,
+					}},
+					// server_padding (0x12e0, BoringSSL-internal, payload 4000) is
+					// Beta-only. Stable omits it. Uncomment to match Beta.
+					// &tls.GenericExtension{Id: 0x12e0, Data: []byte{0x0f, 0xa0}},
+					&tls.GenericExtension{Id: 0xca34, Data: chrome153TrustAnchors}, // https://source.chromium.org/search?q=TLSEXT_TYPE_trust_anchors https://issues.chromium.org/issues/398275713
+					&tls.UtlsGREASEExtension{},
+				},
+			}, nil
+		},
+	},
+	settings: map[http2.SettingID]uint32{
+		http2.SettingHeaderTableSize:   65536,
+		http2.SettingEnablePush:        0,
+		http2.SettingInitialWindowSize: 6291456,
+		http2.SettingMaxHeaderListSize: 262144,
+	},
+	settingsOrder: []http2.SettingID{
+		http2.SettingHeaderTableSize,
+		http2.SettingEnablePush,
+		http2.SettingInitialWindowSize,
+		http2.SettingMaxHeaderListSize,
+	},
+	pseudoHeaderOrder: []string{
+		":method",
+		":authority",
+		":scheme",
+		":path",
+	},
+	connectionFlow: 15663105,
+}
+
 var Chrome_152_PSK = ClientProfile{
 	clientHelloId: tls.ClientHelloID{
 		Client:               "Chrome",

--- a/profiles/profiles.go
+++ b/profiles/profiles.go
@@ -36,6 +36,8 @@ var MappedTLSClients = map[string]ClientProfile{
 	"chrome_150_PSK":         Chrome_150_PSK,
 	"chrome_152":             Chrome_152,
 	"chrome_152_PSK":         Chrome_152_PSK,
+	"chrome_153":             Chrome_153,
+	"chrome_153_PSK":         Chrome_153_PSK,
 	"brave_146":              Brave_146,
 	"brave_146_PSK":          Brave_146_PSK,
 	"safari_15_6_1":          Safari_15_6_1,

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -18,6 +18,8 @@ func TestClients(t *testing.T) {
 	firefox_147(t)
 	t.Log("testing chrome 146 with PSK")
 	chrome_146_PSK(t)
+	t.Log("testing chrome 153 with PSK")
+	chrome_153_PSK(t)
 	t.Log("testing chrome 152 with PSK")
 	chrome_152_PSK(t)
 	t.Log("testing chrome 150 with PSK")
@@ -685,6 +687,47 @@ func chrome_152_PSK(t *testing.T) {
 	}
 
 	compareResponse(t, "chrome", clientFingerprints[chrome][profiles.Chrome_152_PSK.GetClientHelloStr()], resp)
+}
+
+func chrome_153_PSK(t *testing.T) {
+	options := []tls_client.HttpClientOption{
+		skipPeetCertVerify,
+		tls_client.WithClientProfile(profiles.Chrome_153_PSK),
+		tls_client.WithTimeoutSeconds(120),
+	}
+
+	client, err := tls_client.NewHttpClient(nil, options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, peetApiEndpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header = defaultHeader
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compareResponse(t, "chrome", clientFingerprints[chrome][profiles.Chrome_153.GetClientHelloStr()], resp)
+
+	req, err = http.NewRequest(http.MethodGet, peetApiEndpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req.Header = defaultHeader
+
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	compareResponse(t, "chrome", clientFingerprints[chrome][profiles.Chrome_153_PSK.GetClientHelloStr()], resp)
 }
 
 func chrome_150_PSK(t *testing.T) {

--- a/tests/client_test_utils.go
+++ b/tests/client_test_utils.go
@@ -121,6 +121,26 @@ var clientFingerprints = map[string]map[string]map[string]string{
 			akamaiFingerprint:     "1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p",
 			akamaiFingerprintHash: "52d84b11737d980aef856699f885ca86",
 		},
+		// Chrome_153 shares JA3/JA4/akamai fingerprints with Chrome_152 —
+		// the profiles differ only in the trust_anchors extension payload
+		// bytes and the profile Version label, and JA3/JA4 do not read
+		// extension contents. TestTrustAnchors covers the payload delta.
+		profiles.Chrome_153.GetClientHelloStr(): map[string]string{
+			ja3String:             "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,17613-43-18-65037-51-13-10-27-23-35-0-65281-45-11-5-16-51764,4588-29-23-24,0",
+			ja3Hash:               "5d510aa7220d1a7bc1256493e4b88909",
+			ja4String:             "t13d1517h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,002b,002d,0033,44cd,ca34,fe0d,ff01_0904,0905,0906,0403,0804,0401,0503,0805,0501,0806,0601",
+			ja4Hash:               "t13d1517h2_8daaf6152771_cb7bf5808d99",
+			akamaiFingerprint:     "1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p",
+			akamaiFingerprintHash: "52d84b11737d980aef856699f885ca86",
+		},
+		profiles.Chrome_153_PSK.GetClientHelloStr(): map[string]string{
+			ja3String:             "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,17613-43-18-65037-51-13-10-27-23-35-0-65281-45-11-5-16-51764-41,4588-29-23-24,0",
+			ja3Hash:               "b725019d0bcb612810eb226664682342",
+			ja4String:             "t13d1518h2_002f,0035,009c,009d,1301,1302,1303,c013,c014,c02b,c02c,c02f,c030,cca8,cca9_0005,000a,000b,000d,0012,0017,001b,0023,0029,002b,002d,0033,44cd,ca34,fe0d,ff01_0904,0905,0906,0403,0804,0401,0503,0805,0501,0806,0601",
+			ja4Hash:               "t13d1518h2_8daaf6152771_e2d80978ab2e",
+			akamaiFingerprint:     "1:65536;2:0;4:6291456;6:262144|15663105|0|m,a,s,p",
+			akamaiFingerprintHash: "52d84b11737d980aef856699f885ca86",
+		},
 		profiles.Chrome_150.GetClientHelloStr(): map[string]string{
 			ja3String:             "771,4865-4866-4867-49195-49199-49196-49200-52393-52392-49171-49172-156-157-47-53,17613-43-18-65037-51-13-10-27-23-35-0-65281-45-11-5-16,4588-29-23-24,0",
 			ja3Hash:               "eeee4c6725bf89c31f225b3dab4cef37",

--- a/tests/grease_signature_scheme_test.go
+++ b/tests/grease_signature_scheme_test.go
@@ -12,6 +12,8 @@ import (
 var greaseSignatureSchemeProfiles = map[string]profiles.ClientProfile{
 	"Chrome_152":     profiles.Chrome_152,
 	"Chrome_152_PSK": profiles.Chrome_152_PSK,
+	"Chrome_153":     profiles.Chrome_153,
+	"Chrome_153_PSK": profiles.Chrome_153_PSK,
 }
 
 // TestGreaseSignatureSchemeIsRandom builds ClientHello specs offline and checks

--- a/tests/trust_anchors_test.go
+++ b/tests/trust_anchors_test.go
@@ -32,12 +32,19 @@ var trustAnchorProfiles = []struct {
 }{
 	{"Chrome_152", profiles.Chrome_152, chrome152TrustAnchorsCapture},
 	{"Chrome_152_PSK", profiles.Chrome_152_PSK, chrome152TrustAnchorsCapture},
+	{"Chrome_153", profiles.Chrome_153, chrome153TrustAnchorsCapture},
+	{"Chrome_153_PSK", profiles.Chrome_153_PSK, chrome153TrustAnchorsCapture},
 }
 
 // chrome152TrustAnchorsCapture is the payload as stable Chrome 152.0.7977.64 on
 // Android sent it. The profile keeps its IDs and gives them a new order, so a
 // ClientHello that repeats this exact order means the reordering did not run.
 const chrome152TrustAnchorsCapture = "00b80582df13020108839a648c9b2d010c08839a648c9b2d010704d679090c08839a648c9b2d010a04d679090b08839a648c9b2d010d0582df13020e08839a648c9b2d010b04d67909050582df13020d0582df13021404d679090404d679090804d679090d04d679090a04d679090708839a648c9b2d011204d67909010582df13020608839a648c9b2d01080582df13021208839a648c9b2d011304d679090f0582df13021308839a648c9b2d01090582df13020f04d6790906"
+
+// chrome153TrustAnchorsCapture is the payload as stable Chrome 153.0.8010.37 on
+// Windows 11 25H2 (fresh user profile) sent it. Same 28 anchor IDs as the
+// Chrome 152 capture in a different absl::flat_hash_set iteration order.
+const chrome153TrustAnchorsCapture = "00b80582df13020d08839a648c9b2d01070582df13021408839a648c9b2d010a04d679090708839a648c9b2d01090582df13020e04d679090108839a648c9b2d010808839a648c9b2d010b04d679090f04d679090408839a648c9b2d010d04d679090c08839a648c9b2d010c04d67909060582df13021204d679090808839a648c9b2d011204d67909050582df13020604d679090b0582df13021304d679090d0582df13020108839a648c9b2d011304d679090a0582df13020f"
 
 // splitTrustAnchors parses a RequestedTrustAnchorList the way a server does. It
 // returns the IDs in the order they arrived and fails the test on a malformed


### PR DESCRIPTION
Adds `Chrome_153` and `Chrome_153_PSK`, cloned from the Chrome 152 pair. The profiles differ from Chrome 152 only in the profile `Version` label and in the `trust_anchors` extension payload — JA3 and JA4 do not read extension contents, so the hashes match Chrome 152. `TestTrustAnchors` covers the payload delta.

## ClientHello over Chrome 152

Same 16 cipher suites, same 17/18 extensions in the same positions, same `signature_algorithms` with a random GREASE value first, same key shares (GREASE, X25519MLKEM768, X25519), same supported groups, same `trust_anchors` extension (0xca34) — with a Chrome 153 capture in place of the Chrome 152 one.

## The trust_anchors capture

`profiles/extension_data.go` gains one hex capture from stable Chrome 153.0.8010.37 on Windows 11 25H2: 186 bytes carrying the same 28 trust anchor IDs as the Chrome 152 capture, in a different `absl::flat_hash_set` iteration order.

Two consecutive captures from the same clean Chrome profile returned identical bytes, and two captures from separate Chrome processes returned the same IDs in different orders — the behaviour the existing `shuffleTrustAnchors` was written to model.

## Fingerprints

Captured from `tls.peet.ws/api/all` on 2026-09-09.

| Profile          | JA3 hash                           | JA4                                    |
| ---------------- | ---------------------------------- | -------------------------------------- |
| `Chrome_153`     | `5d510aa7220d1a7bc1256493e4b88909` | `t13d1517h2_8daaf6152771_cb7bf5808d99` |
| `Chrome_153_PSK` | `b725019d0bcb612810eb226664682342` | `t13d1518h2_8daaf6152771_e2d80978ab2e` |

Hashes match Chrome_152 and Chrome_152_PSK — the extension set and order did not change between the two versions, and JA3/JA4 do not read the `trust_anchors` payload. `TestTrustAnchors` covers the payload delta.

## Tests

The new rows appear in the four profile tables that #265 introduced:

- `tests/client_test_utils.go` — expected JA3/JA4/akamai fingerprints for Chrome_153 and Chrome_153_PSK.
- `tests/client_test.go` — `TestClients` gains a `chrome_153_PSK` step; the helper walks one client through a first ClientHello (no cached ticket, matches `Chrome_153`) and a second ClientHello (session ticket resumed, matches `Chrome_153_PSK`), same pattern as `chrome_152_PSK`.
- `tests/grease_signature_scheme_test.go` — Chrome_153 and Chrome_153_PSK rows in `greaseSignatureSchemeProfiles`.
- `tests/trust_anchors_test.go` — Chrome_153 and Chrome_153_PSK rows in `trustAnchorProfiles`, plus the new `chrome153TrustAnchorsCapture` const.

## Verification

- \`go build ./...\` — clean.
- \`go test ./tests/ -run '^TestClients\$' -count=1\` — passes for all 33+ profiles in 65 s. Chrome_153 and Chrome_153_PSK produce the expected fingerprints on tls.peet.ws.
- \`go test ./tests/ -run 'TrustAnchors|Grease' -count=1\` — passes. `TestTrustAnchorsAreAcceptedByAServer` reaches `https://www.google.com/generate_204` with certificate verification on and answers 204 for both new profiles, so the payload holds against a server that reads the trust anchor IDs draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)